### PR TITLE
persist job cancellation to db worker token identity binding readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# Chola CI
+
+A distributed CI/CD build orchestrator for on-premises deployments. Workers reserve resources, execute multi-stage pipelines with pre/post scripts, and stream logs in real-time.
+
+## Architecture
+
+```
+┌─────────────┐     gRPC      ┌─────────────┐     sh -c      ┌───────────┐
+│  Controller  │◄────────────►│   Worker(s)  │──────────────►│  Builds   │
+│  (Rust)     │               │   (Rust)     │               │           │
+└──────┬──────┘               └──────────────┘               └───────────┘
+       │ REST API
+┌──────┴──────┐    ┌──────────┐    ┌───────┐
+│  Dashboard  │    │ Postgres │    │ Redis │
+│  (React)    │    └──────────┘    └───────┘
+└─────────────┘
+```
+
+**Controller** — schedules jobs, manages workers, serves REST API + gRPC  
+**Worker** — executes build commands, streams logs, reports status  
+**ci-job-runner** — CLI for Jenkins/scripts to reserve workers and run stages  
+**Dashboard** — React frontend for builds, workers, repos, settings
+
+## Quick Start
+
+```bash
+# Prerequisites: Rust, PostgreSQL, Redis, Node.js 18+
+
+# Database
+psql -U postgres -c "CREATE DATABASE choladb; CREATE USER chola_app WITH PASSWORD 'secret'; GRANT CONNECT, CREATE ON DATABASE choladb TO chola_app;"
+
+# Start services
+just watch-controller    # Terminal 1
+just watch-worker worker-1  # Terminal 2
+just frontend-dev        # Terminal 3 → http://localhost:3000
+```
+
+## Build Pipeline
+
+```bash
+# Reserve a worker for a multi-stage build
+just reserve my-repo abc123 "build,test"
+
+# Run stages sequentially
+just run-stage <GROUP_ID> build
+just run-stage <GROUP_ID> test
+```
+
+## Features
+
+- **Multi-stage pipelines** with DAG dependencies
+- **Pre/post scripts** — global (per-repo) and per-stage, worker or controller scope
+- **Resource-based scheduling** — CPU/memory/disk allocation, least-loaded worker selection
+- **Worker management** — register, drain, delete, label groups, token-based auth
+- **Live log streaming** via gRPC + SSE, persisted to disk
+- **Reservation timeouts** — idle and stall detection with automatic cleanup
+- **Workspace isolation** — per-build directories with git bare mirror caching
+- **Web dashboard** — builds, workers, repos, stages, scripts, tokens, settings, analytics
+- **Security** — JWT + API keys + per-worker tokens, secret masking in logs
+- **Webhooks** — GitHub/GitLab triggers with HMAC verification
+
+## Auth
+
+```bash
+# Worker: register in dashboard → get token
+token: "chola_wkr_xxx"   # in worker config
+# or
+CHOLA_TOKEN=chola_wkr_xxx  # env var
+
+# Runner: create at dashboard → Tokens → Runner tab
+CHOLA_TOKEN=chola_svc_xxx just reserve ...
+```
+
+## Tech Stack
+
+- **Backend:** Rust, tonic (gRPC), axum (REST), sqlx (PostgreSQL), deadpool-redis
+- **Frontend:** React 19, TypeScript, Vite, TailwindCSS, TanStack Query, Zustand
+- **Infra:** PostgreSQL, Redis, Vector (log shipping), Nix (builds)
+
+## Configuration
+
+See [`config/controller.example.yaml`](config/controller.example.yaml) and [`config/worker-1.example.yaml`](config/worker-1.example.yaml).
+
+Data directory: `$CHOLA_HOME` → `$XDG_DATA_HOME/chola` → `~/.local/share/chola`
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/crates/ci-controller/src/api/job_group_handlers.rs
+++ b/crates/ci-controller/src/api/job_group_handlers.rs
@@ -298,16 +298,36 @@ pub async fn cancel(
                 ));
             }
         }
-        let info = jg
-            .get(&id)
-            .map(|g| (g.reserved_worker_id.clone(), g.allocated_resources));
+        let info = jg.get(&id).map(|g| {
+            (
+                g.reserved_worker_id.clone(),
+                g.allocated_resources,
+                g.repo_id,
+                g.branch.clone(),
+                g.commit_sha.clone(),
+            )
+        });
         jg.update_state(&id, JobGroupState::Cancelled);
         jg.fail_group_jobs(&id, "Cancelled via API");
         info
     };
 
+    // Dispatch global post-script before releasing worker resources
+    if let Some((Some(ref wid), _, repo_id, ref branch, ref commit_sha)) = release_info {
+        crate::grpc_server::dispatch_global_post_script(
+            &state,
+            &id,
+            wid,
+            repo_id,
+            branch.clone(),
+            commit_sha.clone(),
+            JobGroupState::Cancelled,
+        )
+        .await;
+    }
+
     // Release allocated resources on the worker
-    if let Some((Some(wid), alloc)) = &release_info {
+    if let Some((Some(ref wid), alloc, _, _, _)) = release_info {
         if alloc.cpu > 0 || alloc.memory_mb > 0 || alloc.disk_mb > 0 {
             let mut wr = state.worker_registry.write().await;
             if let Some(w) = wr.get_mut(wid) {
@@ -317,7 +337,7 @@ pub async fn cancel(
     }
 
     // Release Redis reservation so the worker can accept new groups
-    if let Some((Some(wid), _)) = &release_info {
+    if let Some((Some(ref wid), _, _, _, _)) = release_info {
         if let Some(redis) = &state.redis_store {
             if let Err(e) = crate::reservation::ReservationManager::release(redis, wid, &id).await {
                 warn!("Failed to release Redis reservation for worker {wid}: {e}");

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -1244,35 +1244,66 @@ impl Orchestrator for OrchestratorService {
         if !req.worker_token.is_empty() {
             let hash = sha256_hex(&req.worker_token);
             if let Some(st) = storage {
-                match st.get_worker_by_token_hash(&hash).await {
-                    Ok(Some(row)) => {
-                        if !row.approved {
-                            return Err(Status::permission_denied("Worker is not approved"));
-                        }
-                        // Cache worker token hash so the interceptor accepts it
-                        if let Ok(mut guard) = self.state.token_hashes.write() {
-                            guard.insert(hash.clone());
-                        }
-                        let worker_id = row.worker_id.clone();
-                        let mut registry = self.state.worker_registry.write().await;
-                        registry.register_with_id(&worker_id, &req);
-                        restore_allocations(&self.state, &mut registry, &worker_id).await;
-                        drop(registry);
-                        return Ok(Response::new(RegisterResponse {
-                            accepted: true,
-                            message: "Worker authenticated".to_string(),
-                            heartbeat_interval_secs: hb_interval,
-                            worker_token: String::new(),
-                            assigned_worker_id: worker_id,
-                        }));
-                    }
-                    Ok(None) => {
-                        return Err(Status::unauthenticated("Invalid worker token"));
-                    }
+                // Resolve worker_id from the token table (authoritative binding).
+                // Falls back to req.worker_id only if no binding exists (legacy token).
+                let bound_worker_id = match st.get_token_worker_id(&hash).await {
+                    Ok(id) => id,
                     Err(e) => {
                         return Err(Status::internal(format!("Token lookup failed: {}", e)));
                     }
+                };
+
+                let worker_id = match bound_worker_id {
+                    Some(id) => id,
+                    None => {
+                        // Legacy path: token exists in hash set but has no binding.
+                        // Validate via workers table to ensure token is known.
+                        match st.get_worker_by_token_hash(&hash).await {
+                            Ok(Some(row)) => row.worker_id.clone(),
+                            Ok(None) => {
+                                return Err(Status::unauthenticated("Invalid worker token"));
+                            }
+                            Err(e) => {
+                                return Err(Status::internal(format!(
+                                    "Worker lookup failed: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                };
+
+                // Check worker approval status.
+                match st.get_worker(&worker_id).await {
+                    Ok(Some(row)) if !row.approved => {
+                        return Err(Status::permission_denied("Worker is not approved"));
+                    }
+                    Err(e) => {
+                        return Err(Status::internal(format!(
+                            "Worker approval check failed: {}",
+                            e
+                        )));
+                    }
+                    _ => {}
                 }
+
+                // Cache token hash so the interceptor accepts subsequent RPCs.
+                if let Ok(mut guard) = self.state.token_hashes.write() {
+                    guard.insert(hash.clone());
+                }
+
+                let mut registry = self.state.worker_registry.write().await;
+                registry.register_with_id(&worker_id, &req);
+                restore_allocations(&self.state, &mut registry, &worker_id).await;
+                drop(registry);
+
+                return Ok(Response::new(RegisterResponse {
+                    accepted: true,
+                    message: "Worker authenticated".to_string(),
+                    heartbeat_interval_secs: hb_interval,
+                    worker_token: String::new(),
+                    assigned_worker_id: worker_id,
+                }));
             }
         }
 
@@ -1418,9 +1449,22 @@ impl Orchestrator for OrchestratorService {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
         let state = self.state.clone();
 
-        // Register this worker's channel for job assignments (including cancel directives)
+        // Register this worker's channel for job assignments (including cancel directives).
+        // Reject if an active stream already exists to prevent hijacking.
         {
             let mut senders = self.state.job_stream_senders.write().await;
+            if let Some(existing) = senders.get(&worker_id) {
+                if !existing.is_closed() {
+                    warn!(
+                        "Worker {} already has active job stream, rejecting duplicate",
+                        worker_id
+                    );
+                    return Err(Status::already_exists(format!(
+                        "Worker {} already has an active connection",
+                        worker_id
+                    )));
+                }
+            }
             senders.insert(worker_id.clone(), tx.clone());
             info!("Registered job stream channel for worker {}", worker_id);
         }
@@ -1736,12 +1780,48 @@ impl Orchestrator for OrchestratorService {
         &self,
         request: Request<ReconnectRequest>,
     ) -> Result<Response<ReconnectResponse>, Status> {
+        // Extract bearer token from metadata before consuming the request.
+        let bearer_token: Option<String> = request
+            .metadata()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.strip_prefix("Bearer "))
+            .map(|s| s.to_owned());
+
         let req = request.into_inner();
         warn!(
             "Worker {} reconnecting with {} running jobs",
             req.worker_id,
             req.running_jobs.len()
         );
+
+        // Validate that the bearer token is bound to the claimed worker_id.
+        if let Some(token) = &bearer_token {
+            if token.starts_with("chola_wkr_") || token.starts_with("chola_svc_") {
+                let hash = sha256_hex(token);
+                if let Some(st) = self.state.storage.as_ref() {
+                    match st.get_token_worker_id(&hash).await {
+                        Ok(Some(bound_id)) if bound_id != req.worker_id => {
+                            warn!(
+                                "Reconnect identity mismatch: token bound to '{}', claimed '{}'",
+                                bound_id, req.worker_id
+                            );
+                            return Err(Status::permission_denied(format!(
+                                "Token is bound to worker '{}', not '{}'",
+                                bound_id, req.worker_id
+                            )));
+                        }
+                        Err(e) => {
+                            return Err(Status::internal(format!(
+                                "Token identity check failed: {}",
+                                e
+                            )));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
 
         // Re-register the worker (update heartbeat and mark as active)
         {
@@ -2174,6 +2254,10 @@ impl Orchestrator for OrchestratorService {
                 {
                     warn!("Failed to persist cancel for group {group_id}: {e}");
                 }
+                // Persist job cancellations so they survive restarts
+                if let Err(e) = storage.cancel_jobs_for_group(group_id).await {
+                    warn!("Failed to cancel orphaned jobs in DB for group {group_id}: {e}");
+                }
             }
 
             return Ok(Response::new(CancelJobResponse {
@@ -2389,6 +2473,12 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                                     .await
                                 {
                                     error!("Failed to mark group {gid} as failed after worker death: {e}");
+                                }
+                                // Persist job failures so they survive restarts
+                                if let Err(e) = storage.cancel_jobs_for_group(gid).await {
+                                    warn!(
+                                        "Failed to cancel orphaned jobs in DB for group {gid}: {e}"
+                                    );
                                 }
                             }
                         }

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -1477,7 +1477,7 @@ impl Storage {
     pub async fn load_active_job_groups(&self) -> anyhow::Result<Vec<JobGroup>> {
         let q = format!(
             "SELECT {JOB_GROUP_COLUMNS} FROM job_groups \
-             WHERE state NOT IN ('success', 'failed', 'cancelled') \
+             WHERE state NOT IN ('success', 'failed', 'cancelled', 'expired') \
              ORDER BY created_at"
         );
         let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
@@ -3756,5 +3756,38 @@ impl Storage {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected() > 0)
+    }
+
+    /// Cancel all non-terminal jobs belonging to a group.
+    /// Called when the group transitions to a terminal state.
+    pub async fn cancel_jobs_for_group(&self, group_id: Uuid) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE jobs SET state = 'cancelled', updated_at = now() \
+             WHERE job_group_id = $1 AND state NOT IN ('success', 'failed', 'cancelled')",
+        )
+        .bind(group_id)
+        .execute(&self.pool)
+        .await?;
+        let count = result.rows_affected();
+        if count > 0 {
+            info!("Cancelled {} orphaned jobs for group {}", count, group_id);
+        }
+        Ok(count)
+    }
+
+    /// Cancel jobs that are in non-terminal state but their group is terminal.
+    /// Runs on startup to catch any missed updates from previous crashes.
+    pub async fn cleanup_orphaned_jobs(&self) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE jobs SET state = 'cancelled', updated_at = now() \
+             WHERE state NOT IN ('success', 'failed', 'cancelled') \
+             AND job_group_id IN (\
+                 SELECT id FROM job_groups \
+                 WHERE state IN ('success', 'failed', 'cancelled', 'expired')\
+             )",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 }


### PR DESCRIPTION
- Add `cancel_jobs_for_group()` and `cleanup_orphaned_jobs()` to persist job state to DB when group goes terminal
- Exclude expired groups from startup recovery
- Enforce worker token-to-worker_id binding in register handler
- Dispatch global post-script on REST cancel
- Add project README