### PR TITLE
12: script locking, exit code fixes, resource scheduling, worker priority

### DIFF
--- a/crates/ci-controller/src/api/label_group_handlers.rs
+++ b/crates/ci-controller/src/api/label_group_handlers.rs
@@ -22,6 +22,7 @@ pub struct LabelGroupRequest {
     pub max_concurrent_jobs: Option<i32>,
     pub capabilities: Option<Vec<String>>,
     pub enabled: Option<bool>,
+    pub priority: Option<i32>,
 }
 
 #[derive(Deserialize)]
@@ -33,6 +34,7 @@ pub struct UpdateLabelGroupRequest {
     pub max_concurrent_jobs: Option<i32>,
     pub capabilities: Option<Vec<String>>,
     pub enabled: Option<bool>,
+    pub priority: Option<i32>,
 }
 
 /// POST /api/v1/label-groups
@@ -59,6 +61,7 @@ pub async fn create(
             body.max_concurrent_jobs,
             body.capabilities.as_deref().unwrap_or(&[]),
             body.enabled.unwrap_or(true),
+            body.priority,
         )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -121,6 +124,7 @@ pub async fn update(
             body.max_concurrent_jobs,
             body.capabilities.as_deref(),
             body.enabled,
+            body.priority,
         )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -158,6 +162,7 @@ fn label_group_to_json(g: &crate::storage::DbLabelGroup) -> Value {
         "max_concurrent_jobs": g.max_concurrent_jobs,
         "capabilities": g.capabilities,
         "enabled": g.enabled,
+        "priority": g.priority,
         "created_at": g.created_at.to_rfc3339(),
         "updated_at": g.updated_at.to_rfc3339(),
     })

--- a/crates/ci-controller/src/api/mod.rs
+++ b/crates/ci-controller/src/api/mod.rs
@@ -187,6 +187,7 @@ pub fn api_router() -> Router<Arc<ControllerState>> {
             "/workers/{id}/metadata",
             put(worker_handlers::update_metadata),
         )
+        .route("/workers/{id}/limits", put(worker_handlers::update_limits))
         // Worker tokens
         .route(
             "/worker-tokens",

--- a/crates/ci-controller/src/api/worker_handlers.rs
+++ b/crates/ci-controller/src/api/worker_handlers.rs
@@ -112,6 +112,9 @@ pub async fn list(
                 "max_cpu": w.info.max_cpu,
                 "max_memory_mb": w.info.max_memory_mb,
                 "max_disk_mb": w.info.max_disk_mb,
+                "max_cpu_percent": w.info.max_cpu_percent,
+                "max_memory_percent": w.info.max_memory_percent,
+                "max_disk_percent": w.info.max_disk_percent,
                 "cpu_cap": w.cpu_cap(),
                 "memory_cap": w.memory_cap(),
                 "disk_cap": w.disk_cap(),
@@ -153,6 +156,9 @@ pub async fn list(
                         "max_cpu": row.max_cpu,
                         "max_memory_mb": row.max_memory_mb,
                         "max_disk_mb": row.max_disk_mb,
+                        "max_cpu_percent": row.max_cpu_percent,
+                        "max_memory_percent": row.max_memory_percent,
+                        "max_disk_percent": row.max_disk_percent,
                     }));
                 }
             }
@@ -220,6 +226,9 @@ pub async fn get_one(
         "max_cpu": w.info.max_cpu,
         "max_memory_mb": w.info.max_memory_mb,
         "max_disk_mb": w.info.max_disk_mb,
+        "max_cpu_percent": w.info.max_cpu_percent,
+        "max_memory_percent": w.info.max_memory_percent,
+        "max_disk_percent": w.info.max_disk_percent,
         "cpu_cap": w.cpu_cap(),
         "memory_cap": w.memory_cap(),
         "disk_cap": w.disk_cap(),
@@ -365,6 +374,9 @@ pub struct RegisterWorkerRequest {
     pub max_cpu: Option<i32>,
     pub max_memory_mb: Option<i64>,
     pub max_disk_mb: Option<i64>,
+    pub max_cpu_percent: Option<i32>,
+    pub max_memory_percent: Option<i32>,
+    pub max_disk_percent: Option<i32>,
 }
 
 pub async fn register_worker(
@@ -418,6 +430,9 @@ pub async fn register_worker(
             body.max_cpu,
             body.max_memory_mb,
             body.max_disk_mb,
+            body.max_cpu_percent,
+            body.max_memory_percent,
+            body.max_disk_percent,
         )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -613,6 +628,12 @@ pub struct UpdateLimitsRequest {
     pub max_memory_mb: Option<i64>,
     /// Max disk MB chola may reserve. 0 or null = clear (use total_disk_mb).
     pub max_disk_mb: Option<i64>,
+    /// Max CPU as percentage of total (1-100). 0 or null = clear.
+    pub max_cpu_percent: Option<i32>,
+    /// Max memory as percentage of total (1-100). 0 or null = clear.
+    pub max_memory_percent: Option<i32>,
+    /// Max disk as percentage of total (1-100). 0 or null = clear.
+    pub max_disk_percent: Option<i32>,
 }
 
 /// PUT /api/v1/workers/:id/limits
@@ -636,6 +657,9 @@ pub async fn update_limits(
             body.max_cpu,
             body.max_memory_mb,
             body.max_disk_mb,
+            body.max_cpu_percent,
+            body.max_memory_percent,
+            body.max_disk_percent,
         )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -653,12 +677,20 @@ pub async fn update_limits(
                 .map(|v| if v == 0 { None } else { Some(v as u64) }),
             body.max_disk_mb
                 .map(|v| if v == 0 { None } else { Some(v as u64) }),
+            body.max_cpu_percent
+                .map(|v| if v == 0 { None } else { Some(v) }),
+            body.max_memory_percent
+                .map(|v| if v == 0 { None } else { Some(v) }),
+            body.max_disk_percent
+                .map(|v| if v == 0 { None } else { Some(v) }),
         );
     }
 
     info!(
-        "Worker {} limits updated by {}: priority={:?} max_cpu={:?} max_memory_mb={:?} max_disk_mb={:?}",
-        id, auth_user.username, body.priority, body.max_cpu, body.max_memory_mb, body.max_disk_mb
+        "Worker {} limits updated by {}: priority={:?} max_cpu={:?} max_memory_mb={:?} max_disk_mb={:?} \
+         max_cpu_percent={:?} max_memory_percent={:?} max_disk_percent={:?}",
+        id, auth_user.username, body.priority, body.max_cpu, body.max_memory_mb, body.max_disk_mb,
+        body.max_cpu_percent, body.max_memory_percent, body.max_disk_percent
     );
 
     Ok(Json(json!({
@@ -667,5 +699,8 @@ pub async fn update_limits(
         "max_cpu": row.max_cpu,
         "max_memory_mb": row.max_memory_mb,
         "max_disk_mb": row.max_disk_mb,
+        "max_cpu_percent": row.max_cpu_percent,
+        "max_memory_percent": row.max_memory_percent,
+        "max_disk_percent": row.max_disk_percent,
     })))
 }

--- a/crates/ci-controller/src/api/worker_handlers.rs
+++ b/crates/ci-controller/src/api/worker_handlers.rs
@@ -108,6 +108,13 @@ pub async fn list(
                 "system_info": w.system_info,
                 "active_groups": active_groups,
                 "labels": w.info.labels,
+                "priority": w.info.priority,
+                "max_cpu": w.info.max_cpu,
+                "max_memory_mb": w.info.max_memory_mb,
+                "max_disk_mb": w.info.max_disk_mb,
+                "cpu_cap": w.cpu_cap(),
+                "memory_cap": w.memory_cap(),
+                "disk_cap": w.disk_cap(),
             })
         })
         .collect();
@@ -142,6 +149,10 @@ pub async fn list(
                         "active_groups": [],
                         "labels": row.labels,
                         "description": row.description,
+                        "priority": row.priority,
+                        "max_cpu": row.max_cpu,
+                        "max_memory_mb": row.max_memory_mb,
+                        "max_disk_mb": row.max_disk_mb,
                     }));
                 }
             }
@@ -205,6 +216,13 @@ pub async fn get_one(
         "disk_details": w.info.disk_details,
         "system_info": w.system_info,
         "labels": w.info.labels,
+        "priority": w.info.priority,
+        "max_cpu": w.info.max_cpu,
+        "max_memory_mb": w.info.max_memory_mb,
+        "max_disk_mb": w.info.max_disk_mb,
+        "cpu_cap": w.cpu_cap(),
+        "memory_cap": w.memory_cap(),
+        "disk_cap": w.disk_cap(),
     })))
 }
 
@@ -343,6 +361,10 @@ pub struct RegisterWorkerRequest {
     pub hostname: String,
     pub labels: Option<Vec<String>>,
     pub description: Option<String>,
+    pub priority: Option<i32>,
+    pub max_cpu: Option<i32>,
+    pub max_memory_mb: Option<i64>,
+    pub max_disk_mb: Option<i64>,
 }
 
 pub async fn register_worker(
@@ -392,6 +414,10 @@ pub async fn register_worker(
             &token_name,
             &token_hash,
             &auth_user.username,
+            body.priority,
+            body.max_cpu,
+            body.max_memory_mb,
+            body.max_disk_mb,
         )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -575,4 +601,71 @@ pub async fn undrain(
         ))),
         None => Err(ApiError::NotFound(format!("Worker '{}' not found", id))),
     }
+}
+
+/// Request body for PUT /api/v1/workers/:id/limits
+#[derive(Deserialize)]
+pub struct UpdateLimitsRequest {
+    pub priority: Option<i32>,
+    /// Max CPU cores chola may reserve. 0 or null = clear (use total_cpu).
+    pub max_cpu: Option<i32>,
+    /// Max memory MB chola may reserve. 0 or null = clear (use total_memory_mb).
+    pub max_memory_mb: Option<i64>,
+    /// Max disk MB chola may reserve. 0 or null = clear (use total_disk_mb).
+    pub max_disk_mb: Option<i64>,
+}
+
+/// PUT /api/v1/workers/:id/limits
+pub async fn update_limits(
+    State(state): State<Arc<ControllerState>>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateLimitsRequest>,
+) -> Result<Json<Value>, ApiError> {
+    if !auth_user.role.can_manage_workers() {
+        return Err(ApiError::Forbidden("Insufficient permissions".into()));
+    }
+
+    let storage = state.storage.as_ref().ok_or(ApiError::StorageUnavailable)?;
+
+    // Persist to DB
+    let row = storage
+        .update_worker_priority_limits(
+            &id,
+            body.priority,
+            body.max_cpu,
+            body.max_memory_mb,
+            body.max_disk_mb,
+        )
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+        .ok_or_else(|| ApiError::NotFound(format!("Worker '{}' not found", id)))?;
+
+    // Update in-memory registry if worker is live
+    {
+        let mut registry = state.worker_registry.write().await;
+        registry.update_priority_limits(
+            &id,
+            body.priority,
+            body.max_cpu
+                .map(|v| if v == 0 { None } else { Some(v as u32) }),
+            body.max_memory_mb
+                .map(|v| if v == 0 { None } else { Some(v as u64) }),
+            body.max_disk_mb
+                .map(|v| if v == 0 { None } else { Some(v as u64) }),
+        );
+    }
+
+    info!(
+        "Worker {} limits updated by {}: priority={:?} max_cpu={:?} max_memory_mb={:?} max_disk_mb={:?}",
+        id, auth_user.username, body.priority, body.max_cpu, body.max_memory_mb, body.max_disk_mb
+    );
+
+    Ok(Json(json!({
+        "worker_id": row.worker_id,
+        "priority": row.priority,
+        "max_cpu": row.max_cpu,
+        "max_memory_mb": row.max_memory_mb,
+        "max_disk_mb": row.max_disk_mb,
+    })))
 }

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -8,13 +8,13 @@ use tracing::{error, info, warn};
 use ci_core::models::job::{Job, JobType};
 use ci_core::proto::orchestrator::{
     orchestrator_server::{Orchestrator, OrchestratorServer},
-    CancelDirective, CancelJobRequest, CancelJobResponse, GetJobGroupStatusRequest,
-    GetJobGroupStatusResponse, GetJobStatusRequest, GetJobStatusResponse, HeartbeatAck,
-    HeartbeatMessage, JobAssignment, JobStatusAck, JobStatusUpdate, JobStreamRequest, LogAck,
-    LogChunk, LogResumeDirective, ReconnectRequest, ReconnectResponse, RegisterRequest,
-    RegisterResponse, ReserveWorkerRequest, ReserveWorkerResponse, ScriptLockConfig,
-    SubmitJobRequest, SubmitJobResponse, SubmitStageRequest, SubmitStageResponse,
-    WatchJobLogsRequest,
+    AcquireLockRequest, AcquireLockResponse, CancelDirective, CancelJobRequest, CancelJobResponse,
+    GetJobGroupStatusRequest, GetJobGroupStatusResponse, GetJobStatusRequest, GetJobStatusResponse,
+    HeartbeatAck, HeartbeatMessage, JobAssignment, JobStatusAck, JobStatusUpdate, JobStreamRequest,
+    LogAck, LogChunk, LogResumeDirective, ReconnectRequest, ReconnectResponse, RegisterRequest,
+    RegisterResponse, ReleaseLockRequest, ReleaseLockResponse, ReserveWorkerRequest,
+    ReserveWorkerResponse, ScriptLockConfig, SubmitJobRequest, SubmitJobResponse,
+    SubmitStageRequest, SubmitStageResponse, WatchJobLogsRequest,
 };
 
 use crate::dag;
@@ -166,6 +166,7 @@ pub async fn dispatch_global_post_script(
             enabled: true,
             lock_key: repo.global_post_script_lock_key.clone().unwrap_or_default(),
             timeout_secs: repo.global_post_script_lock_timeout_secs,
+            scope: repo.global_post_script_scope.clone(),
         })
     } else {
         None
@@ -977,11 +978,13 @@ async fn do_submit_stage(
                 enabled: true,
                 lock_key: s.lock_key.clone().unwrap_or_default(),
                 timeout_secs: s.lock_timeout_secs,
+                scope: s.script_scope.clone(),
             });
             let post_lk = post_s.filter(|s| s.lock_enabled).map(|s| ScriptLockConfig {
                 enabled: true,
                 lock_key: s.lock_key.clone().unwrap_or_default(),
                 timeout_secs: s.lock_timeout_secs,
+                scope: s.script_scope.clone(),
             });
             (pre, post, pre_lk, post_lk)
         } else {
@@ -1018,6 +1021,7 @@ async fn do_submit_stage(
                                         .clone()
                                         .unwrap_or_default(),
                                     timeout_secs: repo.global_pre_script_lock_timeout_secs,
+                                    scope: repo.global_pre_script_scope.clone(),
                                 });
                             }
                         }
@@ -2589,6 +2593,54 @@ impl Orchestrator for OrchestratorService {
             "Job group {} not found",
             req.job_group_id
         )))
+    }
+
+    async fn acquire_lock(
+        &self,
+        request: Request<AcquireLockRequest>,
+    ) -> Result<Response<AcquireLockResponse>, Status> {
+        let req = request.into_inner();
+
+        let redis = self
+            .state
+            .redis_store
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("Redis not configured"))?;
+
+        let ttl = req.timeout_secs.max(1) as u64;
+        let acquired = redis
+            .acquire_lock_with_holder(&req.lock_key, &req.holder_id, ttl)
+            .await
+            .map_err(|e| Status::internal(format!("Redis error: {}", e)))?;
+
+        Ok(Response::new(AcquireLockResponse {
+            acquired,
+            message: if acquired {
+                "Lock acquired".into()
+            } else {
+                "Lock held by another".into()
+            },
+        }))
+    }
+
+    async fn release_lock(
+        &self,
+        request: Request<ReleaseLockRequest>,
+    ) -> Result<Response<ReleaseLockResponse>, Status> {
+        let req = request.into_inner();
+
+        let redis = self
+            .state
+            .redis_store
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("Redis not configured"))?;
+
+        let released = redis
+            .release_lock_with_holder(&req.lock_key, &req.holder_id)
+            .await
+            .map_err(|e| Status::internal(format!("Redis error: {}", e)))?;
+
+        Ok(Response::new(ReleaseLockResponse { released }))
     }
 }
 

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -486,17 +486,21 @@ pub async fn do_reserve_worker(
     let has_resource_req = needed_cpu > 0 || needed_memory > 0 || needed_disk > 0;
     let worker_id = {
         let mut registry = state.worker_registry.write().await;
-        // Sort candidates: most free resources first
+        // Sort candidates: highest priority first, then most free resources
         candidate_ids.sort_by(|a, b| {
-            let free_a = registry
-                .get(a)
-                .map(|w| w.available_cpu() as u64 + w.available_memory_mb() + w.free_disk_mb())
-                .unwrap_or(0);
-            let free_b = registry
-                .get(b)
-                .map(|w| w.available_cpu() as u64 + w.available_memory_mb() + w.free_disk_mb())
-                .unwrap_or(0);
-            free_b.cmp(&free_a) // descending: most free first
+            let wa = registry.get(a);
+            let wb = registry.get(b);
+            let pri_a = wa.map(|w| w.info.priority).unwrap_or(0);
+            let pri_b = wb.map(|w| w.info.priority).unwrap_or(0);
+            pri_b.cmp(&pri_a).then_with(|| {
+                let free_a = wa
+                    .map(|w| w.available_cpu() as u64 + w.available_memory_mb() + w.free_disk_mb())
+                    .unwrap_or(0);
+                let free_b = wb
+                    .map(|w| w.available_cpu() as u64 + w.available_memory_mb() + w.free_disk_mb())
+                    .unwrap_or(0);
+                free_b.cmp(&free_a)
+            })
         });
         let mut selected = None;
         for wid in &candidate_ids {
@@ -1334,19 +1338,20 @@ impl Orchestrator for OrchestratorService {
                     }
                 };
 
-                // Check worker approval status.
-                match st.get_worker(&worker_id).await {
+                // Check worker approval status and load DB-set limits.
+                let db_row = match st.get_worker(&worker_id).await {
                     Ok(Some(row)) if !row.approved => {
                         return Err(Status::permission_denied("Worker is not approved"));
                     }
+                    Ok(Some(row)) => Some(row),
+                    Ok(None) => None,
                     Err(e) => {
                         return Err(Status::internal(format!(
                             "Worker approval check failed: {}",
                             e
                         )));
                     }
-                    _ => {}
-                }
+                };
 
                 // Cache token hash so the interceptor accepts subsequent RPCs.
                 if let Ok(mut guard) = self.state.token_hashes.write() {
@@ -1355,6 +1360,18 @@ impl Orchestrator for OrchestratorService {
 
                 let mut registry = self.state.worker_registry.write().await;
                 registry.register_with_id(&worker_id, &req);
+
+                // Apply admin-set priority/limits from DB to in-memory state
+                if let Some(row) = &db_row {
+                    registry.update_priority_limits(
+                        &worker_id,
+                        Some(row.priority),
+                        Some(row.max_cpu.map(|v| v as u32)),
+                        Some(row.max_memory_mb.map(|v| v as u64)),
+                        Some(row.max_disk_mb.map(|v| v as u64)),
+                    );
+                }
+
                 restore_allocations(&self.state, &mut registry, &worker_id).await;
                 drop(registry);
 
@@ -1396,9 +1413,13 @@ impl Orchestrator for OrchestratorService {
                             registration_token_id: Some(token.id),
                             approved: true,
                             description: None,
+                            priority: 0,
+                            max_cpu: None,
+                            max_memory_mb: None,
+                            max_disk_mb: None,
                         };
 
-                        st.upsert_worker(&worker_row).await.map_err(|e| {
+                        let persisted = st.upsert_worker(&worker_row).await.map_err(|e| {
                             Status::internal(format!("Failed to persist worker: {}", e))
                         })?;
 
@@ -1414,6 +1435,16 @@ impl Orchestrator for OrchestratorService {
                         let worker_id = req.worker_id.clone();
                         let mut registry = self.state.worker_registry.write().await;
                         registry.register(&req);
+
+                        // Apply DB-preserved priority/limits to in-memory state
+                        registry.update_priority_limits(
+                            &worker_id,
+                            Some(persisted.priority),
+                            Some(persisted.max_cpu.map(|v| v as u32)),
+                            Some(persisted.max_memory_mb.map(|v| v as u64)),
+                            Some(persisted.max_disk_mb.map(|v| v as u64)),
+                        );
+
                         restore_allocations(&self.state, &mut registry, &worker_id).await;
                         drop(registry);
 

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -1369,6 +1369,9 @@ impl Orchestrator for OrchestratorService {
                         Some(row.max_cpu.map(|v| v as u32)),
                         Some(row.max_memory_mb.map(|v| v as u64)),
                         Some(row.max_disk_mb.map(|v| v as u64)),
+                        Some(row.max_cpu_percent),
+                        Some(row.max_memory_percent),
+                        Some(row.max_disk_percent),
                     );
                 }
 
@@ -1417,6 +1420,9 @@ impl Orchestrator for OrchestratorService {
                             max_cpu: None,
                             max_memory_mb: None,
                             max_disk_mb: None,
+                            max_cpu_percent: None,
+                            max_memory_percent: None,
+                            max_disk_percent: None,
                         };
 
                         let persisted = st.upsert_worker(&worker_row).await.map_err(|e| {
@@ -1443,6 +1449,9 @@ impl Orchestrator for OrchestratorService {
                             Some(persisted.max_cpu.map(|v| v as u32)),
                             Some(persisted.max_memory_mb.map(|v| v as u64)),
                             Some(persisted.max_disk_mb.map(|v| v as u64)),
+                            Some(persisted.max_cpu_percent),
+                            Some(persisted.max_memory_percent),
+                            Some(persisted.max_disk_percent),
                         );
 
                         restore_allocations(&self.state, &mut registry, &worker_id).await;

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -602,6 +602,10 @@ fn worker_row_to_state(row: &storage::WorkerRow) -> WorkerState {
         docker_enabled: row.docker_enabled,
         labels: Vec::new(),
         disk_details: Vec::new(),
+        priority: row.priority,
+        max_cpu: row.max_cpu.map(|v| v as u32),
+        max_memory_mb: row.max_memory_mb.map(|v| v as u64),
+        max_disk_mb: row.max_disk_mb.map(|v| v as u64),
     };
     WorkerState {
         info,

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -606,6 +606,9 @@ fn worker_row_to_state(row: &storage::WorkerRow) -> WorkerState {
         max_cpu: row.max_cpu.map(|v| v as u32),
         max_memory_mb: row.max_memory_mb.map(|v| v as u64),
         max_disk_mb: row.max_disk_mb.map(|v| v as u64),
+        max_cpu_percent: row.max_cpu_percent,
+        max_memory_percent: row.max_memory_percent,
+        max_disk_percent: row.max_disk_percent,
     };
     WorkerState {
         info,

--- a/crates/ci-controller/src/redis_store.rs
+++ b/crates/ci-controller/src/redis_store.rs
@@ -315,6 +315,57 @@ impl RedisStore {
         Ok(released)
     }
 
+    /// Acquire a generic distributed lock using a caller-provided holder ID.
+    /// Returns true if the lock was acquired, false if held by another.
+    pub async fn acquire_lock_with_holder(
+        &self,
+        lock_name: &str,
+        holder_id: &str,
+        ttl_secs: u64,
+    ) -> anyhow::Result<bool> {
+        let mut conn = self.get_conn().await?;
+        let key = self.key(&["lock", lock_name]);
+        let result: Option<String> = redis::cmd("SET")
+            .arg(&key)
+            .arg(holder_id)
+            .arg("NX")
+            .arg("EX")
+            .arg(ttl_secs)
+            .query_async(&mut conn)
+            .await?;
+        Ok(result.is_some())
+    }
+
+    /// Release a generic distributed lock only if the holder matches.
+    /// Uses a Lua script for atomic check-and-delete.
+    /// Returns true if the lock was actually released.
+    pub async fn release_lock_with_holder(
+        &self,
+        lock_name: &str,
+        holder_id: &str,
+    ) -> anyhow::Result<bool> {
+        let mut conn = self.get_conn().await?;
+        let key = self.key(&["lock", lock_name]);
+
+        let script = redis::Script::new(
+            r#"
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                redis.call('DEL', KEYS[1])
+                return 1
+            else
+                return 0
+            end
+            "#,
+        );
+
+        let result: i32 = script
+            .key(&key)
+            .arg(holder_id)
+            .invoke_async(&mut conn)
+            .await?;
+        Ok(result == 1)
+    }
+
     /// Unconditionally delete a generic distributed lock.
     /// Use only for administrative cleanup.
     pub async fn release_lock_force(&self, lock_name: &str) -> anyhow::Result<()> {

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -52,10 +52,19 @@ const JOB_COLUMNS: &str = "id, job_group_id, stage_config_id, stage_name, comman
      post_script, worker_id, state, exit_code, pre_exit_code, post_exit_code, \
      log_path, started_at, completed_at, retry_count, status_reason, created_at, updated_at";
 
+/// Column list for SELECT / RETURNING (contains COALESCE for nullable priority).
 const WORKER_COLUMNS: &str =
     "worker_id, hostname, total_cpu, total_memory_mb, total_disk_mb, disk_type, \
      supported_job_types, docker_enabled, status, last_heartbeat_at, registered_at, labels, \
-     system_info, worker_token_hash, registration_token_id, approved, description";
+     system_info, worker_token_hash, registration_token_id, approved, description, \
+     COALESCE(priority, 0) AS priority, max_cpu, max_memory_mb, max_disk_mb";
+
+/// Raw column list for INSERT (no COALESCE expressions).
+const WORKER_INSERT_COLUMNS: &str =
+    "worker_id, hostname, total_cpu, total_memory_mb, total_disk_mb, disk_type, \
+     supported_job_types, docker_enabled, status, last_heartbeat_at, registered_at, labels, \
+     system_info, worker_token_hash, registration_token_id, approved, description, \
+     priority, max_cpu, max_memory_mb, max_disk_mb";
 
 const RESERVATION_COLUMNS: &str =
     "id, worker_id, job_group_id, reserved_at, expires_at, released_at, release_reason";
@@ -244,6 +253,10 @@ impl From<sqlx::postgres::PgRow> for WorkerRow {
             registration_token_id: r.get("registration_token_id"),
             approved: r.try_get("approved").unwrap_or(true),
             description: r.get("description"),
+            priority: r.try_get("priority").unwrap_or(0),
+            max_cpu: r.get("max_cpu"),
+            max_memory_mb: r.get("max_memory_mb"),
+            max_disk_mb: r.get("max_disk_mb"),
         }
     }
 }
@@ -313,6 +326,10 @@ pub struct WorkerRow {
     pub registration_token_id: Option<Uuid>,
     pub approved: bool,
     pub description: Option<String>,
+    pub priority: i32,
+    pub max_cpu: Option<i32>,
+    pub max_memory_mb: Option<i64>,
+    pub max_disk_mb: Option<i64>,
 }
 
 /// Job row from the jobs table (database-level job, not the in-memory Job struct)
@@ -484,6 +501,7 @@ pub struct DbLabelGroup {
     pub max_concurrent_jobs: i32,
     pub capabilities: Vec<String>,
     pub enabled: bool,
+    pub priority: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -501,6 +519,7 @@ impl From<sqlx::postgres::PgRow> for DbLabelGroup {
             max_concurrent_jobs: r.try_get("max_concurrent_jobs").unwrap_or(0),
             capabilities: r.try_get("capabilities").unwrap_or_default(),
             enabled: r.try_get("enabled").unwrap_or(true),
+            priority: r.try_get("priority").unwrap_or(0),
             created_at: r.get("created_at"),
             updated_at: r.get("updated_at"),
         }
@@ -512,7 +531,11 @@ const WORKER_TOKEN_COLUMNS: &str =
 
 const LABEL_GROUP_COLUMNS: &str =
     "id, name, match_labels, env_vars, pre_script, max_concurrent_jobs, \
-     capabilities, enabled, created_at, updated_at";
+     capabilities, enabled, COALESCE(priority, 0) AS priority, created_at, updated_at";
+
+const LABEL_GROUP_INSERT_COLUMNS: &str =
+    "name, match_labels, env_vars, pre_script, max_concurrent_jobs, \
+     capabilities, enabled, priority";
 
 impl Storage {
     /// Create a new Storage with a connection pool.
@@ -745,6 +768,11 @@ impl Storage {
                 31,
                 "script_locking",
                 include_str!("../../../migrations/031_script_locking.sql"),
+            ),
+            (
+                32,
+                "worker_priority_limits",
+                include_str!("../../../migrations/032_worker_priority_limits.sql"),
             ),
         ];
 
@@ -1186,8 +1214,8 @@ impl Storage {
 
     pub async fn upsert_worker(&self, worker: &WorkerRow) -> anyhow::Result<WorkerRow> {
         let q = format!(
-            "INSERT INTO workers ({WORKER_COLUMNS}) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) \
+            "INSERT INTO workers ({WORKER_INSERT_COLUMNS}) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) \
              ON CONFLICT (worker_id) DO UPDATE \
              SET hostname = EXCLUDED.hostname, \
                  total_cpu = EXCLUDED.total_cpu, \
@@ -1201,7 +1229,11 @@ impl Storage {
                  labels = EXCLUDED.labels, \
                  worker_token_hash = COALESCE(EXCLUDED.worker_token_hash, workers.worker_token_hash), \
                  registration_token_id = COALESCE(EXCLUDED.registration_token_id, workers.registration_token_id), \
-                 description = COALESCE(EXCLUDED.description, workers.description) \
+                 description = COALESCE(EXCLUDED.description, workers.description), \
+                 priority = COALESCE(EXCLUDED.priority, workers.priority), \
+                 max_cpu = COALESCE(EXCLUDED.max_cpu, workers.max_cpu), \
+                 max_memory_mb = COALESCE(EXCLUDED.max_memory_mb, workers.max_memory_mb), \
+                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb) \
              RETURNING {WORKER_COLUMNS}"
         );
         let row = sqlx::query(&q)
@@ -1222,6 +1254,10 @@ impl Storage {
             .bind(worker.registration_token_id)
             .bind(worker.approved)
             .bind(&worker.description)
+            .bind(worker.priority)
+            .bind(worker.max_cpu)
+            .bind(worker.max_memory_mb)
+            .bind(worker.max_disk_mb)
             .fetch_one(&self.pool)
             .await?;
 
@@ -1252,6 +1288,44 @@ impl Storage {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+
+    /// Update scheduling priority and resource limits for a worker.
+    /// Pass None for any field to leave it unchanged.
+    /// Pass Some(0) for max_cpu/max_memory_mb/max_disk_mb to clear the limit
+    /// (the column is set to NULL, meaning "use total_* value").
+    pub async fn update_worker_priority_limits(
+        &self,
+        worker_id: &str,
+        priority: Option<i32>,
+        max_cpu: Option<i32>,
+        max_memory_mb: Option<i64>,
+        max_disk_mb: Option<i64>,
+    ) -> anyhow::Result<Option<WorkerRow>> {
+        // Use CASE WHEN to allow setting columns to NULL (via 0 = clear):
+        // - priority: COALESCE (0 is valid, NULL = don't change)
+        // - max_*: provided flag -> if true, use value (NULLIF to clear on 0)
+        let q = format!(
+            "UPDATE workers SET \
+             priority = COALESCE($2, priority), \
+             max_cpu = CASE WHEN $3::bool THEN NULLIF($4, 0) ELSE max_cpu END, \
+             max_memory_mb = CASE WHEN $5::bool THEN NULLIF($6::bigint, 0) ELSE max_memory_mb END, \
+             max_disk_mb = CASE WHEN $7::bool THEN NULLIF($8::bigint, 0) ELSE max_disk_mb END \
+             WHERE worker_id = $1 \
+             RETURNING {WORKER_COLUMNS}"
+        );
+        let row = sqlx::query(&q)
+            .bind(worker_id)
+            .bind(priority)
+            .bind(max_cpu.is_some())
+            .bind(max_cpu.unwrap_or(0))
+            .bind(max_memory_mb.is_some())
+            .bind(max_memory_mb.unwrap_or(0))
+            .bind(max_disk_mb.is_some())
+            .bind(max_disk_mb.unwrap_or(0))
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(WorkerRow::from))
     }
 
     pub async fn update_worker_status(
@@ -3661,22 +3735,36 @@ impl Storage {
         token_name: &str,
         token_hash: &str,
         created_by: &str,
+        priority: Option<i32>,
+        max_cpu: Option<i32>,
+        max_memory_mb: Option<i64>,
+        max_disk_mb: Option<i64>,
     ) -> anyhow::Result<()> {
         let mut tx = self.pool.begin().await?;
 
         // 1. Upsert worker row
         sqlx::query(
-            "INSERT INTO workers (worker_id, hostname, status, registered_at, docker_enabled, labels, description, approved) \
-             VALUES ($1, $2, 'offline', now(), false, $3, $4, true) \
+            "INSERT INTO workers (worker_id, hostname, status, registered_at, docker_enabled, \
+             labels, description, approved, priority, max_cpu, max_memory_mb, max_disk_mb) \
+             VALUES ($1, $2, 'offline', now(), false, $3, $4, true, \
+                     COALESCE($5, 0), $6, $7, $8) \
              ON CONFLICT (worker_id) DO UPDATE \
              SET hostname = EXCLUDED.hostname, \
                  labels = EXCLUDED.labels, \
-                 description = COALESCE(EXCLUDED.description, workers.description)"
+                 description = COALESCE(EXCLUDED.description, workers.description), \
+                 priority = COALESCE(EXCLUDED.priority, workers.priority), \
+                 max_cpu = COALESCE(EXCLUDED.max_cpu, workers.max_cpu), \
+                 max_memory_mb = COALESCE(EXCLUDED.max_memory_mb, workers.max_memory_mb), \
+                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb)",
         )
         .bind(worker_id)
         .bind(hostname)
         .bind(labels)
         .bind(description)
+        .bind(priority)
+        .bind(max_cpu)
+        .bind(max_memory_mb)
+        .bind(max_disk_mb)
         .execute(&mut *tx)
         .await?;
 
@@ -3710,14 +3798,15 @@ impl Storage {
         max_concurrent_jobs: Option<i32>,
         capabilities: &[String],
         enabled: bool,
+        priority: Option<i32>,
     ) -> anyhow::Result<DbLabelGroup> {
         let default_env = serde_json::json!({});
         let ev = env_vars.unwrap_or(&default_env);
         let mcj = max_concurrent_jobs.unwrap_or(0);
+        let pri = priority.unwrap_or(0);
         let q = format!(
-            "INSERT INTO label_groups (name, match_labels, env_vars, pre_script, \
-             max_concurrent_jobs, capabilities, enabled) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7) \
+            "INSERT INTO label_groups ({LABEL_GROUP_INSERT_COLUMNS}) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
              RETURNING {LABEL_GROUP_COLUMNS}"
         );
         let row = sqlx::query(&q)
@@ -3728,6 +3817,7 @@ impl Storage {
             .bind(mcj)
             .bind(capabilities)
             .bind(enabled)
+            .bind(pri)
             .fetch_one(&self.pool)
             .await?;
         Ok(DbLabelGroup::from(row))
@@ -3756,6 +3846,7 @@ impl Storage {
         max_concurrent_jobs: Option<i32>,
         capabilities: Option<&[String]>,
         enabled: Option<bool>,
+        priority: Option<i32>,
     ) -> anyhow::Result<Option<DbLabelGroup>> {
         let q = format!(
             "UPDATE label_groups SET \
@@ -3766,6 +3857,7 @@ impl Storage {
              max_concurrent_jobs = COALESCE($6, max_concurrent_jobs), \
              capabilities = COALESCE($7, capabilities), \
              enabled = COALESCE($8, enabled), \
+             priority = COALESCE($9, priority), \
              updated_at = now() \
              WHERE id = $1 \
              RETURNING {LABEL_GROUP_COLUMNS}"
@@ -3779,6 +3871,7 @@ impl Storage {
             .bind(max_concurrent_jobs)
             .bind(capabilities)
             .bind(enabled)
+            .bind(priority)
             .fetch_optional(&self.pool)
             .await?;
         Ok(row.map(DbLabelGroup::from))

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -57,14 +57,16 @@ const WORKER_COLUMNS: &str =
     "worker_id, hostname, total_cpu, total_memory_mb, total_disk_mb, disk_type, \
      supported_job_types, docker_enabled, status, last_heartbeat_at, registered_at, labels, \
      system_info, worker_token_hash, registration_token_id, approved, description, \
-     COALESCE(priority, 0) AS priority, max_cpu, max_memory_mb, max_disk_mb";
+     COALESCE(priority, 0) AS priority, max_cpu, max_memory_mb, max_disk_mb, \
+     max_cpu_percent, max_memory_percent, max_disk_percent";
 
 /// Raw column list for INSERT (no COALESCE expressions).
 const WORKER_INSERT_COLUMNS: &str =
     "worker_id, hostname, total_cpu, total_memory_mb, total_disk_mb, disk_type, \
      supported_job_types, docker_enabled, status, last_heartbeat_at, registered_at, labels, \
      system_info, worker_token_hash, registration_token_id, approved, description, \
-     priority, max_cpu, max_memory_mb, max_disk_mb";
+     priority, max_cpu, max_memory_mb, max_disk_mb, \
+     max_cpu_percent, max_memory_percent, max_disk_percent";
 
 const RESERVATION_COLUMNS: &str =
     "id, worker_id, job_group_id, reserved_at, expires_at, released_at, release_reason";
@@ -257,6 +259,9 @@ impl From<sqlx::postgres::PgRow> for WorkerRow {
             max_cpu: r.get("max_cpu"),
             max_memory_mb: r.get("max_memory_mb"),
             max_disk_mb: r.get("max_disk_mb"),
+            max_cpu_percent: r.get("max_cpu_percent"),
+            max_memory_percent: r.get("max_memory_percent"),
+            max_disk_percent: r.get("max_disk_percent"),
         }
     }
 }
@@ -330,6 +335,9 @@ pub struct WorkerRow {
     pub max_cpu: Option<i32>,
     pub max_memory_mb: Option<i64>,
     pub max_disk_mb: Option<i64>,
+    pub max_cpu_percent: Option<i32>,
+    pub max_memory_percent: Option<i32>,
+    pub max_disk_percent: Option<i32>,
 }
 
 /// Job row from the jobs table (database-level job, not the in-memory Job struct)
@@ -1215,7 +1223,7 @@ impl Storage {
     pub async fn upsert_worker(&self, worker: &WorkerRow) -> anyhow::Result<WorkerRow> {
         let q = format!(
             "INSERT INTO workers ({WORKER_INSERT_COLUMNS}) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24) \
              ON CONFLICT (worker_id) DO UPDATE \
              SET hostname = EXCLUDED.hostname, \
                  total_cpu = EXCLUDED.total_cpu, \
@@ -1233,7 +1241,10 @@ impl Storage {
                  priority = COALESCE(EXCLUDED.priority, workers.priority), \
                  max_cpu = COALESCE(EXCLUDED.max_cpu, workers.max_cpu), \
                  max_memory_mb = COALESCE(EXCLUDED.max_memory_mb, workers.max_memory_mb), \
-                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb) \
+                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb), \
+                 max_cpu_percent = COALESCE(EXCLUDED.max_cpu_percent, workers.max_cpu_percent), \
+                 max_memory_percent = COALESCE(EXCLUDED.max_memory_percent, workers.max_memory_percent), \
+                 max_disk_percent = COALESCE(EXCLUDED.max_disk_percent, workers.max_disk_percent) \
              RETURNING {WORKER_COLUMNS}"
         );
         let row = sqlx::query(&q)
@@ -1258,6 +1269,9 @@ impl Storage {
             .bind(worker.max_cpu)
             .bind(worker.max_memory_mb)
             .bind(worker.max_disk_mb)
+            .bind(worker.max_cpu_percent)
+            .bind(worker.max_memory_percent)
+            .bind(worker.max_disk_percent)
             .fetch_one(&self.pool)
             .await?;
 
@@ -1301,6 +1315,9 @@ impl Storage {
         max_cpu: Option<i32>,
         max_memory_mb: Option<i64>,
         max_disk_mb: Option<i64>,
+        max_cpu_percent: Option<i32>,
+        max_memory_percent: Option<i32>,
+        max_disk_percent: Option<i32>,
     ) -> anyhow::Result<Option<WorkerRow>> {
         // Use CASE WHEN to allow setting columns to NULL (via 0 = clear):
         // - priority: COALESCE (0 is valid, NULL = don't change)
@@ -1310,7 +1327,10 @@ impl Storage {
              priority = COALESCE($2, priority), \
              max_cpu = CASE WHEN $3::bool THEN NULLIF($4, 0) ELSE max_cpu END, \
              max_memory_mb = CASE WHEN $5::bool THEN NULLIF($6::bigint, 0) ELSE max_memory_mb END, \
-             max_disk_mb = CASE WHEN $7::bool THEN NULLIF($8::bigint, 0) ELSE max_disk_mb END \
+             max_disk_mb = CASE WHEN $7::bool THEN NULLIF($8::bigint, 0) ELSE max_disk_mb END, \
+             max_cpu_percent = CASE WHEN $9::bool THEN NULLIF($10, 0) ELSE max_cpu_percent END, \
+             max_memory_percent = CASE WHEN $11::bool THEN NULLIF($12, 0) ELSE max_memory_percent END, \
+             max_disk_percent = CASE WHEN $13::bool THEN NULLIF($14, 0) ELSE max_disk_percent END \
              WHERE worker_id = $1 \
              RETURNING {WORKER_COLUMNS}"
         );
@@ -1323,6 +1343,12 @@ impl Storage {
             .bind(max_memory_mb.unwrap_or(0))
             .bind(max_disk_mb.is_some())
             .bind(max_disk_mb.unwrap_or(0))
+            .bind(max_cpu_percent.is_some())
+            .bind(max_cpu_percent.unwrap_or(0))
+            .bind(max_memory_percent.is_some())
+            .bind(max_memory_percent.unwrap_or(0))
+            .bind(max_disk_percent.is_some())
+            .bind(max_disk_percent.unwrap_or(0))
             .fetch_optional(&self.pool)
             .await?;
         Ok(row.map(WorkerRow::from))
@@ -3739,15 +3765,19 @@ impl Storage {
         max_cpu: Option<i32>,
         max_memory_mb: Option<i64>,
         max_disk_mb: Option<i64>,
+        max_cpu_percent: Option<i32>,
+        max_memory_percent: Option<i32>,
+        max_disk_percent: Option<i32>,
     ) -> anyhow::Result<()> {
         let mut tx = self.pool.begin().await?;
 
         // 1. Upsert worker row
         sqlx::query(
             "INSERT INTO workers (worker_id, hostname, status, registered_at, docker_enabled, \
-             labels, description, approved, priority, max_cpu, max_memory_mb, max_disk_mb) \
+             labels, description, approved, priority, max_cpu, max_memory_mb, max_disk_mb, \
+             max_cpu_percent, max_memory_percent, max_disk_percent) \
              VALUES ($1, $2, 'offline', now(), false, $3, $4, true, \
-                     COALESCE($5, 0), $6, $7, $8) \
+                     COALESCE($5, 0), $6, $7, $8, $9, $10, $11) \
              ON CONFLICT (worker_id) DO UPDATE \
              SET hostname = EXCLUDED.hostname, \
                  labels = EXCLUDED.labels, \
@@ -3755,7 +3785,10 @@ impl Storage {
                  priority = COALESCE(EXCLUDED.priority, workers.priority), \
                  max_cpu = COALESCE(EXCLUDED.max_cpu, workers.max_cpu), \
                  max_memory_mb = COALESCE(EXCLUDED.max_memory_mb, workers.max_memory_mb), \
-                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb)",
+                 max_disk_mb = COALESCE(EXCLUDED.max_disk_mb, workers.max_disk_mb), \
+                 max_cpu_percent = COALESCE(EXCLUDED.max_cpu_percent, workers.max_cpu_percent), \
+                 max_memory_percent = COALESCE(EXCLUDED.max_memory_percent, workers.max_memory_percent), \
+                 max_disk_percent = COALESCE(EXCLUDED.max_disk_percent, workers.max_disk_percent)",
         )
         .bind(worker_id)
         .bind(hostname)
@@ -3765,6 +3798,9 @@ impl Storage {
         .bind(max_cpu)
         .bind(max_memory_mb)
         .bind(max_disk_mb)
+        .bind(max_cpu_percent)
+        .bind(max_memory_percent)
+        .bind(max_disk_percent)
         .execute(&mut *tx)
         .await?;
 

--- a/crates/ci-controller/src/worker_registry.rs
+++ b/crates/ci-controller/src/worker_registry.rs
@@ -52,6 +52,9 @@ impl WorkerRegistry {
             max_cpu: None,
             max_memory_mb: None,
             max_disk_mb: None,
+            max_cpu_percent: None,
+            max_memory_percent: None,
+            max_disk_percent: None,
         };
 
         let state = WorkerState::new(info);
@@ -97,6 +100,9 @@ impl WorkerRegistry {
             max_cpu: None,
             max_memory_mb: None,
             max_disk_mb: None,
+            max_cpu_percent: None,
+            max_memory_percent: None,
+            max_disk_percent: None,
         };
 
         let state = WorkerState::new(info);
@@ -266,6 +272,9 @@ impl WorkerRegistry {
         max_cpu: Option<Option<u32>>,
         max_memory_mb: Option<Option<u64>>,
         max_disk_mb: Option<Option<u64>>,
+        max_cpu_percent: Option<Option<i32>>,
+        max_memory_percent: Option<Option<i32>>,
+        max_disk_percent: Option<Option<i32>>,
     ) -> bool {
         if let Some(worker) = self.workers.get_mut(worker_id) {
             if let Some(p) = priority {
@@ -279,6 +288,15 @@ impl WorkerRegistry {
             }
             if let Some(md) = max_disk_mb {
                 worker.info.max_disk_mb = md;
+            }
+            if let Some(mcp) = max_cpu_percent {
+                worker.info.max_cpu_percent = mcp;
+            }
+            if let Some(mmp) = max_memory_percent {
+                worker.info.max_memory_percent = mmp;
+            }
+            if let Some(mdp) = max_disk_percent {
+                worker.info.max_disk_percent = mdp;
             }
             true
         } else {

--- a/crates/ci-controller/src/worker_registry.rs
+++ b/crates/ci-controller/src/worker_registry.rs
@@ -48,6 +48,10 @@ impl WorkerRegistry {
             docker_enabled: req.docker_enabled,
             labels: req.labels.clone(),
             disk_details,
+            priority: 0,
+            max_cpu: None,
+            max_memory_mb: None,
+            max_disk_mb: None,
         };
 
         let state = WorkerState::new(info);
@@ -89,6 +93,10 @@ impl WorkerRegistry {
             docker_enabled: req.docker_enabled,
             labels: req.labels.clone(),
             disk_details,
+            priority: 0,
+            max_cpu: None,
+            max_memory_mb: None,
+            max_disk_mb: None,
         };
 
         let state = WorkerState::new(info);
@@ -248,6 +256,34 @@ impl WorkerRegistry {
         }
 
         timed_out
+    }
+
+    /// Update priority and resource limits for a worker. Returns true if found.
+    pub fn update_priority_limits(
+        &mut self,
+        worker_id: &str,
+        priority: Option<i32>,
+        max_cpu: Option<Option<u32>>,
+        max_memory_mb: Option<Option<u64>>,
+        max_disk_mb: Option<Option<u64>>,
+    ) -> bool {
+        if let Some(worker) = self.workers.get_mut(worker_id) {
+            if let Some(p) = priority {
+                worker.info.priority = p;
+            }
+            if let Some(mc) = max_cpu {
+                worker.info.max_cpu = mc;
+            }
+            if let Some(mm) = max_memory_mb {
+                worker.info.max_memory_mb = mm;
+            }
+            if let Some(md) = max_disk_mb {
+                worker.info.max_disk_mb = md;
+            }
+            true
+        } else {
+            false
+        }
     }
 
     /// Remove a worker entirely from the registry.

--- a/crates/ci-core/proto/orchestrator.proto
+++ b/crates/ci-core/proto/orchestrator.proto
@@ -44,6 +44,10 @@ service Orchestrator {
 
   // Client gets job group status with all stage states
   rpc GetJobGroupStatus (GetJobGroupStatusRequest) returns (GetJobGroupStatusResponse);
+
+  // Distributed lock (Redis-backed, for controller-scope script locking)
+  rpc AcquireLock (AcquireLockRequest) returns (AcquireLockResponse);
+  rpc ReleaseLock (ReleaseLockRequest) returns (ReleaseLockResponse);
 }
 
 // ============================================================================
@@ -146,6 +150,27 @@ message ScriptLockConfig {
   bool enabled = 1;
   string lock_key = 2;        // template: "{{WORKER_ID}}-{{REPO_NAME}}-pre"
   int32 timeout_secs = 3;     // total time for lock acquisition + script execution
+  string scope = 4;           // "worker" (flock, default) or "controller" (Redis via gRPC)
+}
+
+message AcquireLockRequest {
+  string lock_key = 1;        // resolved key (after template substitution)
+  int32 timeout_secs = 2;     // TTL for the lock in Redis
+  string holder_id = 3;       // unique ID of the lock holder (for release)
+}
+
+message AcquireLockResponse {
+  bool acquired = 1;
+  string message = 2;
+}
+
+message ReleaseLockRequest {
+  string lock_key = 1;
+  string holder_id = 2;
+}
+
+message ReleaseLockResponse {
+  bool released = 1;
 }
 
 message CancelDirective {

--- a/crates/ci-core/src/models/worker.rs
+++ b/crates/ci-core/src/models/worker.rs
@@ -54,15 +54,24 @@ pub struct WorkerInfo {
     /// Scheduling priority. Higher = preferred. 0 = default.
     #[serde(default)]
     pub priority: i32,
-    /// Max CPU cores chola is allowed to reserve. None = use total_cpu.
+    /// Max CPU cores chola is allowed to reserve. None = no absolute limit.
     #[serde(default)]
     pub max_cpu: Option<u32>,
-    /// Max memory MB chola is allowed to reserve. None = use total_memory_mb.
+    /// Max memory MB chola is allowed to reserve. None = no absolute limit.
     #[serde(default)]
     pub max_memory_mb: Option<u64>,
-    /// Max disk MB chola is allowed to reserve. None = use total_disk_mb.
+    /// Max disk MB chola is allowed to reserve. None = no absolute limit.
     #[serde(default)]
     pub max_disk_mb: Option<u64>,
+    /// Max CPU as percentage of total (1-100). None = no percentage limit.
+    #[serde(default)]
+    pub max_cpu_percent: Option<i32>,
+    /// Max memory as percentage of total (1-100). None = no percentage limit.
+    #[serde(default)]
+    pub max_memory_percent: Option<i32>,
+    /// Max disk as percentage of total (1-100). None = no percentage limit.
+    #[serde(default)]
+    pub max_disk_percent: Option<i32>,
 }
 
 /// Dynamic worker resource snapshot (sent via heartbeat)
@@ -113,19 +122,37 @@ impl WorkerState {
         }
     }
 
-    /// Effective CPU cap: max_cpu if set, otherwise total_cpu.
+    /// Effective CPU cap: min(absolute, percentage) if both set, else whichever is set, else total.
     pub fn cpu_cap(&self) -> u32 {
-        self.info.max_cpu.unwrap_or(self.info.total_cpu)
+        let abs = self.info.max_cpu.unwrap_or(self.info.total_cpu);
+        let pct = self
+            .info
+            .max_cpu_percent
+            .map(|p| (self.info.total_cpu as u64 * p.clamp(1, 100) as u64 / 100) as u32)
+            .unwrap_or(self.info.total_cpu);
+        abs.min(pct)
     }
 
-    /// Effective memory cap: max_memory_mb if set, otherwise total_memory_mb.
+    /// Effective memory cap: min(absolute, percentage) if both set, else whichever is set, else total.
     pub fn memory_cap(&self) -> u64 {
-        self.info.max_memory_mb.unwrap_or(self.info.total_memory_mb)
+        let abs = self.info.max_memory_mb.unwrap_or(self.info.total_memory_mb);
+        let pct = self
+            .info
+            .max_memory_percent
+            .map(|p| self.info.total_memory_mb * p.clamp(1, 100) as u64 / 100)
+            .unwrap_or(self.info.total_memory_mb);
+        abs.min(pct)
     }
 
-    /// Effective disk cap: max_disk_mb if set, otherwise total_disk_mb.
+    /// Effective disk cap: min(absolute, percentage) if both set, else whichever is set, else total.
     pub fn disk_cap(&self) -> u64 {
-        self.info.max_disk_mb.unwrap_or(self.info.total_disk_mb)
+        let abs = self.info.max_disk_mb.unwrap_or(self.info.total_disk_mb);
+        let pct = self
+            .info
+            .max_disk_percent
+            .map(|p| self.info.total_disk_mb * p.clamp(1, 100) as u64 / 100)
+            .unwrap_or(self.info.total_disk_mb);
+        abs.min(pct)
     }
 
     /// Try to allocate resources. Returns false if insufficient capacity.

--- a/crates/ci-core/src/models/worker.rs
+++ b/crates/ci-core/src/models/worker.rs
@@ -51,6 +51,18 @@ pub struct WorkerInfo {
     pub docker_enabled: bool,
     pub labels: Vec<String>,
     pub disk_details: Vec<DiskDetailInfo>,
+    /// Scheduling priority. Higher = preferred. 0 = default.
+    #[serde(default)]
+    pub priority: i32,
+    /// Max CPU cores chola is allowed to reserve. None = use total_cpu.
+    #[serde(default)]
+    pub max_cpu: Option<u32>,
+    /// Max memory MB chola is allowed to reserve. None = use total_memory_mb.
+    #[serde(default)]
+    pub max_memory_mb: Option<u64>,
+    /// Max disk MB chola is allowed to reserve. None = use total_disk_mb.
+    #[serde(default)]
+    pub max_disk_mb: Option<u64>,
 }
 
 /// Dynamic worker resource snapshot (sent via heartbeat)
@@ -101,17 +113,30 @@ impl WorkerState {
         }
     }
 
+    /// Effective CPU cap: max_cpu if set, otherwise total_cpu.
+    pub fn cpu_cap(&self) -> u32 {
+        self.info.max_cpu.unwrap_or(self.info.total_cpu)
+    }
+
+    /// Effective memory cap: max_memory_mb if set, otherwise total_memory_mb.
+    pub fn memory_cap(&self) -> u64 {
+        self.info.max_memory_mb.unwrap_or(self.info.total_memory_mb)
+    }
+
+    /// Effective disk cap: max_disk_mb if set, otherwise total_disk_mb.
+    pub fn disk_cap(&self) -> u64 {
+        self.info.max_disk_mb.unwrap_or(self.info.total_disk_mb)
+    }
+
     /// Try to allocate resources. Returns false if insufficient capacity.
-    /// CPU/memory: checked against total - allocated (reservation model).
-    /// Disk: checked against total - actual usage from heartbeat (usage model),
-    /// because disk consumption persists after jobs complete.
+    /// CPU/memory: checked against cap (max or total) - allocated.
+    /// Disk: checked against actual free space from heartbeat, capped by max_disk_mb.
     pub fn allocate(&mut self, cpu: u32, mem: u64, disk: u64) -> bool {
-        if self.allocated_cpu + cpu > self.info.total_cpu
-            || self.allocated_memory_mb + mem > self.info.total_memory_mb
+        if self.allocated_cpu + cpu > self.cpu_cap()
+            || self.allocated_memory_mb + mem > self.memory_cap()
         {
             return false;
         }
-        // Disk uses actual free space, not reservation-based available
         if disk > 0 && self.free_disk_mb() < disk {
             return false;
         }
@@ -129,19 +154,15 @@ impl WorkerState {
     }
 
     pub fn available_cpu(&self) -> u32 {
-        self.info.total_cpu.saturating_sub(self.allocated_cpu)
+        self.cpu_cap().saturating_sub(self.allocated_cpu)
     }
 
     pub fn available_memory_mb(&self) -> u64 {
-        self.info
-            .total_memory_mb
-            .saturating_sub(self.allocated_memory_mb)
+        self.memory_cap().saturating_sub(self.allocated_memory_mb)
     }
 
     pub fn available_disk_mb(&self) -> u64 {
-        self.info
-            .total_disk_mb
-            .saturating_sub(self.allocated_disk_mb)
+        self.disk_cap().saturating_sub(self.allocated_disk_mb)
     }
 
     /// Available memory in MB (from heartbeat)
@@ -152,11 +173,16 @@ impl WorkerState {
         }
     }
 
-    /// Available disk in MB (from heartbeat)
+    /// Available disk in MB (from heartbeat), capped by max_disk_mb if set.
     pub fn free_disk_mb(&self) -> u64 {
-        match &self.last_heartbeat {
+        let physical_free = match &self.last_heartbeat {
             Some(hb) => self.info.total_disk_mb.saturating_sub(hb.used_disk_mb),
             None => self.info.total_disk_mb,
+        };
+        // Cap by max_disk_mb if configured
+        match self.info.max_disk_mb {
+            Some(max) => physical_free.min(max),
+            None => physical_free,
         }
     }
 }

--- a/crates/ci-core/src/models/worker.rs
+++ b/crates/ci-core/src/models/worker.rs
@@ -200,16 +200,12 @@ impl WorkerState {
         }
     }
 
-    /// Available disk in MB (from heartbeat), capped by max_disk_mb if set.
+    /// Available disk in MB (from heartbeat), capped by effective disk limit.
     pub fn free_disk_mb(&self) -> u64 {
         let physical_free = match &self.last_heartbeat {
             Some(hb) => self.info.total_disk_mb.saturating_sub(hb.used_disk_mb),
             None => self.info.total_disk_mb,
         };
-        // Cap by max_disk_mb if configured
-        match self.info.max_disk_mb {
-            Some(max) => physical_free.min(max),
-            None => physical_free,
-        }
+        physical_free.min(self.disk_cap())
     }
 }

--- a/crates/ci-worker/src/grpc_client.rs
+++ b/crates/ci-worker/src/grpc_client.rs
@@ -163,4 +163,20 @@ impl GrpcClient {
             .await?;
         Ok(resp.into_inner())
     }
+
+    pub async fn acquire_lock(
+        &self,
+        req: tonic::Request<ci_core::proto::orchestrator::AcquireLockRequest>,
+    ) -> Result<tonic::Response<ci_core::proto::orchestrator::AcquireLockResponse>, tonic::Status>
+    {
+        self.client.clone().acquire_lock(req).await
+    }
+
+    pub async fn release_lock(
+        &self,
+        req: tonic::Request<ci_core::proto::orchestrator::ReleaseLockRequest>,
+    ) -> Result<tonic::Response<ci_core::proto::orchestrator::ReleaseLockResponse>, tonic::Status>
+    {
+        self.client.clone().release_lock(req).await
+    }
 }

--- a/crates/ci-worker/src/stage_runner.rs
+++ b/crates/ci-worker/src/stage_runner.rs
@@ -12,6 +12,7 @@ pub struct ScriptLockConfig {
     pub enabled: bool,
     pub lock_key: String,
     pub timeout_secs: i32,
+    pub scope: String, // "worker" (flock) or "controller" (Redis via gRPC)
 }
 
 impl ScriptLockConfig {
@@ -21,6 +22,11 @@ impl ScriptLockConfig {
                 enabled: true,
                 lock_key: p.lock_key,
                 timeout_secs: p.timeout_secs,
+                scope: if p.scope.is_empty() {
+                    "worker".into()
+                } else {
+                    p.scope
+                },
             },
             _ => Self::default(),
         }
@@ -48,8 +54,73 @@ impl ScriptLockConfig {
     }
 }
 
-/// Acquire a file lock (flock) with timeout. Returns the lock file handle on success.
-/// Lock files are created under /tmp/chola-locks/.
+fn lock_ts() -> String {
+    chrono::Utc::now().format("%H:%M:%S%.3f").to_string()
+}
+
+async fn lock_log(log_tx: &mpsc::Sender<LogLine>, msg: String, is_stderr: bool) {
+    let _ = log_tx
+        .send(LogLine {
+            line: format!("[LOCK {}] {}", lock_ts(), msg),
+            is_stderr,
+        })
+        .await;
+}
+
+/// Lock guard that auto-releases on drop.
+/// For flock: dropping the File releases the lock.
+/// For controller (gRPC): calls ReleaseLock RPC on drop (best-effort).
+pub enum LockGuard {
+    Flock(std::fs::File),
+    Controller {
+        lock_key: String,
+        holder_id: String,
+        client: crate::grpc_client::GrpcClient,
+    },
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        if let LockGuard::Controller {
+            lock_key,
+            holder_id,
+            client,
+        } = self
+        {
+            let key = lock_key.clone();
+            let hid = holder_id.clone();
+            let c = client.clone();
+            // Fire-and-forget async release (can't await in Drop)
+            tokio::spawn(async move {
+                let req = tonic::Request::new(ci_core::proto::orchestrator::ReleaseLockRequest {
+                    lock_key: key.clone(),
+                    holder_id: hid,
+                });
+                if let Err(e) = c.release_lock(req).await {
+                    tracing::warn!("Failed to release controller lock {}: {}", key, e);
+                }
+            });
+        }
+    }
+}
+
+/// Acquire a lock — dispatches to flock (worker) or gRPC+Redis (controller).
+async fn acquire_lock(
+    config: &ScriptLockConfig,
+    resolved_key: &str,
+    log_tx: &mpsc::Sender<LogLine>,
+    grpc_client: Option<&crate::grpc_client::GrpcClient>,
+) -> anyhow::Result<LockGuard> {
+    if config.scope == "controller" {
+        acquire_controller_lock(resolved_key, config.timeout_secs, log_tx, grpc_client).await
+    } else {
+        acquire_flock(resolved_key, config.timeout_secs, log_tx)
+            .await
+            .map(LockGuard::Flock)
+    }
+}
+
+/// Acquire a file lock (flock) with timeout.
 async fn acquire_flock(
     resolved_key: &str,
     timeout_secs: i32,
@@ -60,7 +131,6 @@ async fn acquire_flock(
     let lock_dir = PathBuf::from("/tmp/chola-locks");
     fs::create_dir_all(&lock_dir)?;
 
-    // Sanitize lock key for filename (max 200 chars to stay under ext4 255 limit)
     let safe_key: String = resolved_key
         .chars()
         .map(|c| {
@@ -74,15 +144,15 @@ async fn acquire_flock(
         .collect();
     let lock_path = lock_dir.join(format!("{}.lock", safe_key));
 
-    let _ = log_tx
-        .send(LogLine {
-            line: format!(
-                "[LOCK] Acquiring lock: {} (timeout {}s)",
-                resolved_key, timeout_secs
-            ),
-            is_stderr: false,
-        })
-        .await;
+    lock_log(
+        log_tx,
+        format!(
+            "Acquiring flock: {} (timeout {}s)",
+            resolved_key, timeout_secs
+        ),
+        false,
+    )
+    .await;
 
     let file = OpenOptions::new()
         .create(true)
@@ -94,33 +164,100 @@ async fn acquire_flock(
         tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs.max(1) as u64);
 
     loop {
-        // Try non-blocking flock
         let fd = std::os::unix::io::AsRawFd::as_raw_fd(&file);
         let result = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
         if result == 0 {
-            let _ = log_tx
-                .send(LogLine {
-                    line: format!("[LOCK] Acquired: {}", resolved_key),
-                    is_stderr: false,
-                })
-                .await;
+            lock_log(log_tx, format!("Acquired flock: {}", resolved_key), false).await;
             return Ok(file);
         }
-        // Only retry on EWOULDBLOCK (lock held by another process).
-        // Any other errno (EBADF, ENOLCK, etc.) is a real error — fail immediately.
         let err = std::io::Error::last_os_error();
         if err.kind() != std::io::ErrorKind::WouldBlock {
             return Err(anyhow::anyhow!("flock failed: {}", err));
         }
-
         if tokio::time::Instant::now() >= deadline {
+            lock_log(
+                log_tx,
+                format!("Timeout after {}s: {}", timeout_secs, resolved_key),
+                true,
+            )
+            .await;
             return Err(anyhow::anyhow!(
-                "Lock timeout after {}s waiting for: {}",
+                "Lock timeout after {}s: {}",
                 timeout_secs,
                 resolved_key
             ));
         }
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    }
+}
 
+/// Acquire a controller-scope lock via gRPC (backed by Redis SET NX EX).
+async fn acquire_controller_lock(
+    resolved_key: &str,
+    timeout_secs: i32,
+    log_tx: &mpsc::Sender<LogLine>,
+    grpc_client: Option<&crate::grpc_client::GrpcClient>,
+) -> anyhow::Result<LockGuard> {
+    let client =
+        grpc_client.ok_or_else(|| anyhow::anyhow!("No gRPC client for controller lock"))?;
+    let holder_id = uuid::Uuid::new_v4().to_string();
+
+    lock_log(
+        log_tx,
+        format!(
+            "Acquiring controller lock: {} (timeout {}s, holder={})",
+            resolved_key,
+            timeout_secs,
+            &holder_id[..8]
+        ),
+        false,
+    )
+    .await;
+
+    let deadline =
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs.max(1) as u64);
+
+    loop {
+        let req = tonic::Request::new(ci_core::proto::orchestrator::AcquireLockRequest {
+            lock_key: resolved_key.to_string(),
+            timeout_secs,
+            holder_id: holder_id.clone(),
+        });
+        match client.acquire_lock(req).await {
+            Ok(resp) => {
+                let resp = resp.into_inner();
+                if resp.acquired {
+                    lock_log(
+                        log_tx,
+                        format!("Acquired controller lock: {}", resolved_key),
+                        false,
+                    )
+                    .await;
+                    return Ok(LockGuard::Controller {
+                        lock_key: resolved_key.to_string(),
+                        holder_id,
+                        client: client.clone(),
+                    });
+                }
+            }
+            Err(e) => {
+                lock_log(log_tx, format!("Lock RPC error: {}", e), true).await;
+            }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            lock_log(
+                log_tx,
+                format!("Timeout after {}s: {}", timeout_secs, resolved_key),
+                true,
+            )
+            .await;
+            return Err(anyhow::anyhow!(
+                "Controller lock timeout after {}s: {}",
+                timeout_secs,
+                resolved_key
+            ));
+        }
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 }

--- a/frontend/src/api/labelGroups.ts
+++ b/frontend/src/api/labelGroups.ts
@@ -9,6 +9,8 @@ export interface LabelGroup {
   max_concurrent_jobs: number;
   capabilities: string[];
   enabled: boolean;
+  /** Scheduling priority for matched workers (0 = default) */
+  priority: number;
   created_at: string;
   updated_at: string;
 }
@@ -21,6 +23,7 @@ export interface LabelGroupRequest {
   max_concurrent_jobs?: number;
   capabilities?: string[];
   enabled?: boolean;
+  priority?: number;
 }
 
 export interface UpdateLabelGroupRequest {
@@ -31,6 +34,7 @@ export interface UpdateLabelGroupRequest {
   max_concurrent_jobs?: number;
   capabilities?: string[];
   enabled?: boolean;
+  priority?: number;
 }
 
 export const listLabelGroups = () =>

--- a/frontend/src/api/workers.ts
+++ b/frontend/src/api/workers.ts
@@ -10,6 +10,9 @@ export interface RegisterWorkerRequest {
   max_cpu?: number;
   max_memory_mb?: number;
   max_disk_mb?: number;
+  max_cpu_percent?: number | null;
+  max_memory_percent?: number | null;
+  max_disk_percent?: number | null;
 }
 
 export interface RegisterWorkerResponse {
@@ -58,6 +61,9 @@ export interface WorkerLimitsRequest {
   max_cpu?: number | null;
   max_memory_mb?: number | null;
   max_disk_mb?: number | null;
+  max_cpu_percent?: number | null;
+  max_memory_percent?: number | null;
+  max_disk_percent?: number | null;
 }
 
 export const updateWorkerLimits = (id: string, limits: WorkerLimitsRequest) =>

--- a/frontend/src/api/workers.ts
+++ b/frontend/src/api/workers.ts
@@ -6,6 +6,10 @@ export interface RegisterWorkerRequest {
   hostname: string;
   labels?: string[];
   description?: string;
+  priority?: number;
+  max_cpu?: number;
+  max_memory_mb?: number;
+  max_disk_mb?: number;
 }
 
 export interface RegisterWorkerResponse {
@@ -48,3 +52,13 @@ export const regenerateWorkerToken = (workerId: string) =>
   apiClient
     .post<RegenerateTokenResponse>(`/workers/${workerId}/regenerate-token`)
     .then((r) => r.data);
+
+export interface WorkerLimitsRequest {
+  priority?: number;
+  max_cpu?: number | null;
+  max_memory_mb?: number | null;
+  max_disk_mb?: number | null;
+}
+
+export const updateWorkerLimits = (id: string, limits: WorkerLimitsRequest) =>
+  apiClient.put(`/workers/${id}/limits`, limits).then((r) => r.data);

--- a/frontend/src/components/ui/ResourceBar.tsx
+++ b/frontend/src/components/ui/ResourceBar.tsx
@@ -1,16 +1,14 @@
 interface Props {
   label: string;
-  total: number;
+  /** Limit (effective cap) — denominator for the reservation bar */
+  limit: number;
+  /** Hardware total — denominator for the usage bar */
+  hardwareTotal: number;
   reserved: number;
   used: number;
   unit: string;
   /** When true, `used` is already a percentage (0-100) rather than an absolute value */
   usedIsPercent?: boolean;
-  /**
-   * Hardware total before any limit cap. When provided and different from `total`,
-   * the label shows "N limit / M total" instead of just "N total".
-   */
-  hardwareTotal?: number;
 }
 
 function getBarColor(percent: number): string {
@@ -21,28 +19,35 @@ function getBarColor(percent: number): string {
 
 export function ResourceBar({
   label,
-  total,
+  limit,
+  hardwareTotal,
   reserved,
   used,
   unit,
   usedIsPercent = false,
-  hardwareTotal,
 }: Props) {
   const clamp = (v: number) => Math.max(0, Math.min(v, 100));
   const safe = (v: number) => (isNaN(v) || v < 0 ? 0 : v);
-  const reservedPct = total > 0 ? clamp((safe(reserved) / total) * 100) : 0;
-  const usedPct = usedIsPercent ? clamp(safe(used)) : (total > 0 ? clamp((safe(used) / total) * 100) : 0);
 
-  const showBoth = hardwareTotal != null && hardwareTotal !== total;
-  const totalLabel = showBoth
-    ? `${total} limit / ${hardwareTotal} ${unit}`
-    : `${total} ${unit}`;
+  // Reserved bar: allocated / limit
+  const reservedPct = limit > 0 ? clamp((safe(reserved) / limit) * 100) : 0;
+  // Usage bar: used / hardwareTotal (always real hardware)
+  const usedPct = usedIsPercent
+    ? clamp(safe(used))
+    : hardwareTotal > 0
+      ? clamp((safe(used) / hardwareTotal) * 100)
+      : 0;
+
+  const hasLimit = limit < hardwareTotal;
+  const headerLabel = hasLimit
+    ? `${label} (${hardwareTotal} ${unit}, limit ${limit})`
+    : `${label} (${hardwareTotal} ${unit})`;
 
   return (
     <div className="space-y-1.5">
-      <div className="text-xs text-slate-400 font-medium">{label} ({totalLabel})</div>
+      <div className="text-xs text-slate-400 font-medium">{headerLabel}</div>
 
-      {/* Reserved bar */}
+      {/* Reserved bar — against limit */}
       <div className="flex items-center gap-2">
         <span className="text-[10px] text-slate-500 w-14 shrink-0">Reserved</span>
         <div className="flex-1 h-2 bg-slate-700 rounded-full overflow-hidden">
@@ -54,11 +59,11 @@ export function ResourceBar({
           )}
         </div>
         <span className="text-[10px] text-slate-400 w-24 text-right shrink-0">
-          {reserved} / {total} {unit}
+          {reserved} / {limit} {unit}
         </span>
       </div>
 
-      {/* Usage bar */}
+      {/* Usage bar — against hardware total */}
       <div className="flex items-center gap-2">
         <span className="text-[10px] text-slate-500 w-14 shrink-0">Usage</span>
         <div className="flex-1 h-2 bg-slate-700 rounded-full overflow-hidden">
@@ -72,7 +77,7 @@ export function ResourceBar({
         <span className="text-[10px] text-slate-400 w-24 text-right shrink-0">
           {usedIsPercent
             ? `${safe(used).toFixed(0)}%`
-            : `${safe(used).toLocaleString()} / ${total.toLocaleString()} ${unit}`}
+            : `${safe(used).toLocaleString()} / ${hardwareTotal.toLocaleString()} ${unit}`}
         </span>
       </div>
     </div>

--- a/frontend/src/components/ui/ResourceBar.tsx
+++ b/frontend/src/components/ui/ResourceBar.tsx
@@ -6,6 +6,11 @@ interface Props {
   unit: string;
   /** When true, `used` is already a percentage (0-100) rather than an absolute value */
   usedIsPercent?: boolean;
+  /**
+   * Hardware total before any limit cap. When provided and different from `total`,
+   * the label shows "N limit / M total" instead of just "N total".
+   */
+  hardwareTotal?: number;
 }
 
 function getBarColor(percent: number): string {
@@ -21,15 +26,21 @@ export function ResourceBar({
   used,
   unit,
   usedIsPercent = false,
+  hardwareTotal,
 }: Props) {
   const clamp = (v: number) => Math.max(0, Math.min(v, 100));
   const safe = (v: number) => (isNaN(v) || v < 0 ? 0 : v);
   const reservedPct = total > 0 ? clamp((safe(reserved) / total) * 100) : 0;
   const usedPct = usedIsPercent ? clamp(safe(used)) : (total > 0 ? clamp((safe(used) / total) * 100) : 0);
 
+  const showBoth = hardwareTotal != null && hardwareTotal !== total;
+  const totalLabel = showBoth
+    ? `${total} limit / ${hardwareTotal} ${unit}`
+    : `${total} ${unit}`;
+
   return (
     <div className="space-y-1.5">
-      <div className="text-xs text-slate-400 font-medium">{label} ({total} {unit})</div>
+      <div className="text-xs text-slate-400 font-medium">{label} ({totalLabel})</div>
 
       {/* Reserved bar */}
       <div className="flex items-center gap-2">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -256,7 +256,8 @@ export default function DashboardPage() {
                   {w.last_heartbeat && w.total_cpu > 0 && (
                     <ResourceBar
                       label="CPU"
-                      total={w.total_cpu}
+                      limit={w.max_cpu ?? w.total_cpu}
+                      hardwareTotal={w.total_cpu}
                       reserved={w.allocated_cpu ?? 0}
                       used={w.last_heartbeat.used_cpu_percent}
                       unit="cores"

--- a/frontend/src/pages/LabelGroupsPage.tsx
+++ b/frontend/src/pages/LabelGroupsPage.tsx
@@ -184,6 +184,7 @@ function LabelGroupFormModal({ initial, onClose, onSaved }: FormModalProps) {
   const [maxConcurrent, setMaxConcurrent] = useState(
     String(initial?.max_concurrent_jobs ?? '0'),
   );
+  const [priority, setPriority] = useState(String(initial?.priority ?? '0'));
   const [enabled, setEnabled] = useState(initial?.enabled ?? true);
   const isEdit = !!initial;
 
@@ -209,6 +210,7 @@ function LabelGroupFormModal({ initial, onClose, onSaved }: FormModalProps) {
       env_vars: Object.keys(envVars).length > 0 ? envVars : undefined,
       pre_script: preScript || undefined,
       max_concurrent_jobs: parseInt(maxConcurrent, 10) || 0,
+      priority: parseInt(priority, 10) || 0,
       enabled,
     };
     if (isEdit) updateMut.mutate(data);
@@ -273,6 +275,17 @@ function LabelGroupFormModal({ initial, onClose, onSaved }: FormModalProps) {
               min="0"
               value={maxConcurrent}
               onChange={(e) => setMaxConcurrent(e.target.value)}
+              className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-slate-300 mb-1">Priority (0 = default, higher = preferred)</label>
+            <input
+              type="number"
+              min="0"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
               className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
@@ -399,6 +412,11 @@ export default function LabelGroupsPage() {
                       >
                         {g.enabled ? 'Enabled' : 'Disabled'}
                       </span>
+                      {g.priority > 0 && (
+                        <span className="text-xs px-1.5 py-0.5 rounded border bg-blue-500/10 text-blue-400 border-blue-500/30">
+                          P:{g.priority}
+                        </span>
+                      )}
                     </div>
 
                     {g.match_labels.length > 0 && (

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { listWorkers, drainWorker, undrainWorker, deleteWorker, updateWorkerLabels, registerWorker, regenerateWorkerToken } from '../api/workers';
-import type { RegisterWorkerResponse, RegenerateTokenResponse } from '../api/workers';
+import { listWorkers, drainWorker, undrainWorker, deleteWorker, updateWorkerLabels, registerWorker, regenerateWorkerToken, updateWorkerLimits } from '../api/workers';
+import type { RegisterWorkerResponse, RegenerateTokenResponse, WorkerLimitsRequest } from '../api/workers';
 import {
   listBranchBlacklist,
   createBranchBlacklist,
@@ -162,6 +162,10 @@ function RegisterWorkerModal({
   const [description, setDescription] = useState('');
   const [labels, setLabels] = useState<string[]>([]);
   const [labelInput, setLabelInput] = useState('');
+  const [regPriority, setRegPriority] = useState('0');
+  const [regMaxCpu, setRegMaxCpu] = useState('');
+  const [regMaxMemGb, setRegMaxMemGb] = useState('');
+  const [regMaxDiskGb, setRegMaxDiskGb] = useState('');
 
   const registerMut = useMutation({
     mutationFn: () =>
@@ -170,6 +174,10 @@ function RegisterWorkerModal({
         hostname: hostname.trim(),
         labels: labels.length > 0 ? labels : undefined,
         description: description.trim() || undefined,
+        priority: parseInt(regPriority, 10) || 0,
+        max_cpu: regMaxCpu !== '' ? parseInt(regMaxCpu, 10) : undefined,
+        max_memory_mb: regMaxMemGb !== '' ? Math.round(parseFloat(regMaxMemGb) * 1024) : undefined,
+        max_disk_mb: regMaxDiskGb !== '' ? Math.round(parseFloat(regMaxDiskGb) * 1024) : undefined,
       }),
     onSuccess: (data) => {
       onSuccess(data);
@@ -271,6 +279,56 @@ function RegisterWorkerModal({
               className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
               placeholder="Optional description for this worker"
             />
+          </div>
+          <div className="pt-2 border-t border-slate-700">
+            <p className="text-xs text-slate-500 mb-2 font-medium uppercase tracking-wider">Resource Limits</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">Priority</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={regPriority}
+                  onChange={(e) => setRegPriority(e.target.value)}
+                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">Max CPU (cores)</label>
+                <input
+                  type="number"
+                  min="1"
+                  value={regMaxCpu}
+                  onChange={(e) => setRegMaxCpu(e.target.value)}
+                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">Max Memory (GB)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={regMaxMemGb}
+                  onChange={(e) => setRegMaxMemGb(e.target.value)}
+                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">Max Disk (GB)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={regMaxDiskGb}
+                  onChange={(e) => setRegMaxDiskGb(e.target.value)}
+                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+              </div>
+            </div>
           </div>
         </div>
         <div className="flex justify-end gap-3 mt-6">
@@ -427,6 +485,82 @@ function InlineLabelsEditor({
         <button
           type="button"
           onClick={() => onSave(labels)}
+          disabled={isPending}
+          className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          {isPending ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1 text-xs bg-slate-700 text-slate-300 rounded hover:bg-slate-600 focus:outline-none focus:ring-1 focus:ring-slate-500"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Inline Limits Editor ──────────────────────────────────────────────────────
+
+function InlineLimitsEditor({
+  workerId,
+  initial,
+  onSave,
+  onCancel,
+  isPending,
+}: {
+  workerId: string;
+  initial: WorkerLimitsRequest;
+  onSave: (limits: WorkerLimitsRequest) => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  const [priority, setPriority] = useState(String(initial.priority ?? 0));
+  const [maxCpu, setMaxCpu] = useState(initial.max_cpu != null ? String(initial.max_cpu) : '');
+  const [maxMemGb, setMaxMemGb] = useState(
+    initial.max_memory_mb != null ? String(parseFloat((initial.max_memory_mb / 1024).toFixed(1))) : '',
+  );
+  const [maxDiskGb, setMaxDiskGb] = useState(
+    initial.max_disk_mb != null ? String(parseFloat((initial.max_disk_mb / 1024).toFixed(1))) : '',
+  );
+
+  function save() {
+    onSave({
+      priority: parseInt(priority, 10) || 0,
+      max_cpu: maxCpu !== '' ? parseInt(maxCpu, 10) : null,
+      max_memory_mb: maxMemGb !== '' ? Math.round(parseFloat(maxMemGb) * 1024) : null,
+      max_disk_mb: maxDiskGb !== '' ? Math.round(parseFloat(maxDiskGb) * 1024) : null,
+    });
+  }
+
+  const inputCls = 'px-2 py-1 text-xs bg-slate-800 border border-slate-600 rounded text-white font-mono w-24 focus:outline-none focus:ring-1 focus:ring-blue-500';
+
+  return (
+    <div className="mt-2 space-y-2" aria-label={`Edit limits for worker ${workerId}`}>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+        <div>
+          <label className="block text-[10px] text-slate-500 mb-0.5">Priority</label>
+          <input type="number" min="0" value={priority} onChange={(e) => setPriority(e.target.value)} className={inputCls} />
+        </div>
+        <div>
+          <label className="block text-[10px] text-slate-500 mb-0.5">Max CPU (cores)</label>
+          <input type="number" min="1" value={maxCpu} onChange={(e) => setMaxCpu(e.target.value)} className={inputCls} placeholder="no limit" />
+        </div>
+        <div>
+          <label className="block text-[10px] text-slate-500 mb-0.5">Max Memory (GB)</label>
+          <input type="number" min="0" step="0.1" value={maxMemGb} onChange={(e) => setMaxMemGb(e.target.value)} className={inputCls} placeholder="no limit" />
+        </div>
+        <div>
+          <label className="block text-[10px] text-slate-500 mb-0.5">Max Disk (GB)</label>
+          <input type="number" min="0" step="0.1" value={maxDiskGb} onChange={(e) => setMaxDiskGb(e.target.value)} className={inputCls} placeholder="no limit" />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={save}
           disabled={isPending}
           className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
@@ -643,6 +777,7 @@ export default function WorkersPage() {
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [editingLabelsId, setEditingLabelsId] = useState<string | null>(null);
   const [labelDraft, setLabelDraft] = useState<string[]>([]);
+  const [editingLimitsId, setEditingLimitsId] = useState<string | null>(null);
   const { data, isLoading, isError } = useQuery({ queryKey: ['workers'], queryFn: () => listWorkers(), refetchInterval: 5000 });
 
   const drainMut = useMutation({
@@ -687,8 +822,19 @@ export default function WorkersPage() {
       toast.error((err as MutationError).userMessage || 'Failed to regenerate token');
     },
   });
+  const updateLimitsMut = useMutation({
+    mutationFn: ({ id, limits }: { id: string; limits: WorkerLimitsRequest }) =>
+      updateWorkerLimits(id, limits),
+    onSuccess: () => {
+      toast.success('Worker limits updated');
+      setEditingLimitsId(null);
+      qc.invalidateQueries({ queryKey: ['workers'] });
+    },
+    onError: (err: unknown) =>
+      toast.error((err as MutationError).userMessage || 'Failed to update limits'),
+  });
 
-  const workers = data?.data ?? [];
+  const workers = [...(data?.data ?? [])].sort((a, b) => a.worker_id.localeCompare(b.worker_id));
 
   return (
     <div className="space-y-4">
@@ -717,7 +863,14 @@ export default function WorkersPage() {
                 <div className="flex items-center gap-3 min-w-0">
                   <StatusBadge status={w.status} size="md" />
                   <div className="min-w-0">
-                    <p className="text-lg font-semibold text-white truncate">{w.worker_id}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="text-lg font-semibold text-white truncate">{w.worker_id}</p>
+                      {w.priority > 0 && (
+                        <span className="text-[11px] px-1.5 py-0.5 rounded border bg-blue-500/10 text-blue-400 border-blue-500/30 shrink-0">
+                          P:{w.priority}
+                        </span>
+                      )}
+                    </div>
                     <p className="text-sm text-slate-400">{w.hostname} &middot; {w.disk_type} &middot; Docker: {w.docker_enabled ? 'Yes' : 'No'}</p>
                   </div>
                 </div>
@@ -781,22 +934,24 @@ export default function WorkersPage() {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                       <ResourceBar
                         label={hasLastKnown ? 'CPU (last known)' : 'CPU'}
-                        total={w.total_cpu}
+                        total={w.max_cpu ?? w.total_cpu}
                         reserved={w.allocated_cpu}
                         used={w.last_heartbeat?.used_cpu_percent ?? 0}
                         unit="cores"
                         usedIsPercent
+                        hardwareTotal={w.max_cpu != null ? w.total_cpu : undefined}
                       />
                       <ResourceBar
                         label={hasLastKnown ? 'Memory (last known)' : 'Memory'}
-                        total={parseFloat((w.total_memory_mb / 1024).toFixed(1))}
+                        total={parseFloat(((w.max_memory_mb ?? w.total_memory_mb) / 1024).toFixed(1))}
                         reserved={parseFloat((w.allocated_memory_mb / 1024).toFixed(1))}
                         used={parseFloat(((w.last_heartbeat?.used_memory_mb ?? 0) / 1024).toFixed(1))}
                         unit="GB"
+                        hardwareTotal={w.max_memory_mb != null ? parseFloat((w.total_memory_mb / 1024).toFixed(1)) : undefined}
                       />
                       <DiskSection
                         usedDiskMb={w.last_heartbeat?.used_disk_mb ?? 0}
-                        totalDiskMb={w.total_disk_mb}
+                        totalDiskMb={w.max_disk_mb ?? w.total_disk_mb}
                         allocatedDiskMb={w.allocated_disk_mb}
                         diskDetails={w.last_heartbeat?.disk_details ?? w.disk_details ?? []}
                         expanded={expandedDisks.has(w.worker_id)}
@@ -896,6 +1051,44 @@ export default function WorkersPage() {
                   />
                 )}
               </div>
+              {/* Resource limits inline edit */}
+              {canManageWorkers && (
+                <div className="mt-3 pt-3 border-t border-slate-800">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-slate-500 font-medium">Limits:</span>
+                    {w.max_cpu != null && (
+                      <span className="text-xs text-slate-400">CPU: {w.max_cpu}</span>
+                    )}
+                    {w.max_memory_mb != null && (
+                      <span className="text-xs text-slate-400">Mem: {parseFloat((w.max_memory_mb / 1024).toFixed(1))} GB</span>
+                    )}
+                    {w.max_disk_mb != null && (
+                      <span className="text-xs text-slate-400">Disk: {parseFloat((w.max_disk_mb / 1024).toFixed(1))} GB</span>
+                    )}
+                    {w.max_cpu == null && w.max_memory_mb == null && w.max_disk_mb == null && (
+                      <span className="text-xs text-slate-600 italic">none</span>
+                    )}
+                    {editingLimitsId !== w.worker_id && (
+                      <button
+                        type="button"
+                        onClick={() => setEditingLimitsId(w.worker_id)}
+                        className="text-xs text-slate-500 hover:text-slate-300 underline focus:outline-none focus:ring-1 focus:ring-blue-500 rounded"
+                      >
+                        Edit Limits
+                      </button>
+                    )}
+                  </div>
+                  {editingLimitsId === w.worker_id && (
+                    <InlineLimitsEditor
+                      workerId={w.worker_id}
+                      initial={{ priority: w.priority, max_cpu: w.max_cpu, max_memory_mb: w.max_memory_mb, max_disk_mb: w.max_disk_mb }}
+                      onSave={(limits) => updateLimitsMut.mutate({ id: w.worker_id, limits })}
+                      onCancel={() => setEditingLimitsId(null)}
+                      isPending={updateLimitsMut.isPending}
+                    />
+                  )}
+                </div>
+              )}
               <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-500">
                 <span>Types: {w.supported_job_types.join(', ')}</span>
                 <span>Registered: <TimeAgo date={w.registered_at} /></span>

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -15,6 +15,7 @@ import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { usePermission } from '../hooks/usePermission';
 import { toast } from 'sonner';
 import type { MutationError, BranchBlacklistEntry, DiskDetail, WorkerSystemInfo, WorkerActiveGroup } from '../types';
+import type { Worker as CholaWorker } from '../types/worker';
 import { PageSkeleton } from '../components/ui/PageSkeleton';
 import { EmptyState } from '../components/ui/EmptyState';
 
@@ -144,6 +145,63 @@ function DiskSection({
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+// ── Resource bars with effective caps ─────────────────────────────────────────
+
+function ResourceBarsSection({ w, hasLastKnown, expandedDisks, setExpandedDisks }: {
+  w: CholaWorker;
+  hasLastKnown: boolean;
+  expandedDisks: Set<string>;
+  setExpandedDisks: React.Dispatch<React.SetStateAction<Set<string>>>;
+}) {
+  const cpuCap = Math.min(
+    w.max_cpu ?? w.total_cpu,
+    w.max_cpu_percent != null ? Math.floor(w.total_cpu * w.max_cpu_percent / 100) : w.total_cpu
+  );
+  const memCapMb = Math.min(
+    w.max_memory_mb ?? w.total_memory_mb,
+    w.max_memory_percent != null ? Math.floor(w.total_memory_mb * w.max_memory_percent / 100) : w.total_memory_mb
+  );
+  const diskCapMb = Math.min(
+    w.max_disk_mb ?? w.total_disk_mb,
+    w.max_disk_percent != null ? Math.floor(w.total_disk_mb * w.max_disk_percent / 100) : w.total_disk_mb
+  );
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <ResourceBar
+        label={hasLastKnown ? 'CPU (last known)' : 'CPU'}
+        total={cpuCap}
+        reserved={w.allocated_cpu}
+        used={w.last_heartbeat?.used_cpu_percent ?? 0}
+        unit="cores"
+        usedIsPercent
+        hardwareTotal={cpuCap < w.total_cpu ? w.total_cpu : undefined}
+      />
+      <ResourceBar
+        label={hasLastKnown ? 'Memory (last known)' : 'Memory'}
+        total={parseFloat((memCapMb / 1024).toFixed(1))}
+        reserved={parseFloat((w.allocated_memory_mb / 1024).toFixed(1))}
+        used={parseFloat(((w.last_heartbeat?.used_memory_mb ?? 0) / 1024).toFixed(1))}
+        unit="GB"
+        hardwareTotal={memCapMb < w.total_memory_mb ? parseFloat((w.total_memory_mb / 1024).toFixed(1)) : undefined}
+      />
+      <DiskSection
+        usedDiskMb={w.last_heartbeat?.used_disk_mb ?? 0}
+        totalDiskMb={diskCapMb}
+        allocatedDiskMb={w.allocated_disk_mb}
+        diskDetails={w.last_heartbeat?.disk_details ?? w.disk_details ?? []}
+        expanded={expandedDisks.has(w.worker_id)}
+        onToggle={() => setExpandedDisks(prev => {
+          const next = new Set(prev);
+          if (next.has(w.worker_id)) next.delete(w.worker_id);
+          else next.add(w.worker_id);
+          return next;
+        })}
+      />
     </div>
   );
 }
@@ -575,14 +633,15 @@ function InlineLimitsEditor({
   const [maxDiskPct, setMaxDiskPct] = useState(initial.max_disk_percent != null ? String(initial.max_disk_percent) : '');
 
   function save() {
+    // Send 0 to clear a limit (backend NULLIF converts 0 → NULL in DB)
     onSave({
       priority: parseInt(priority, 10) || 0,
-      max_cpu: maxCpu !== '' ? parseInt(maxCpu, 10) : null,
-      max_cpu_percent: maxCpuPct !== '' ? parseInt(maxCpuPct, 10) : null,
-      max_memory_mb: maxMemGb !== '' ? Math.round(parseFloat(maxMemGb) * 1024) : null,
-      max_memory_percent: maxMemPct !== '' ? parseInt(maxMemPct, 10) : null,
-      max_disk_mb: maxDiskGb !== '' ? Math.round(parseFloat(maxDiskGb) * 1024) : null,
-      max_disk_percent: maxDiskPct !== '' ? parseInt(maxDiskPct, 10) : null,
+      max_cpu: maxCpu !== '' ? parseInt(maxCpu, 10) : 0,
+      max_cpu_percent: maxCpuPct !== '' ? parseInt(maxCpuPct, 10) : 0,
+      max_memory_mb: maxMemGb !== '' ? Math.round(parseFloat(maxMemGb) * 1024) : 0,
+      max_memory_percent: maxMemPct !== '' ? parseInt(maxMemPct, 10) : 0,
+      max_disk_mb: maxDiskGb !== '' ? Math.round(parseFloat(maxDiskGb) * 1024) : 0,
+      max_disk_percent: maxDiskPct !== '' ? parseInt(maxDiskPct, 10) : 0,
     });
   }
 
@@ -997,38 +1056,7 @@ export default function WorkersPage() {
                         Last known values (worker offline)
                       </p>
                     )}
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                      <ResourceBar
-                        label={hasLastKnown ? 'CPU (last known)' : 'CPU'}
-                        total={w.max_cpu ?? w.total_cpu}
-                        reserved={w.allocated_cpu}
-                        used={w.last_heartbeat?.used_cpu_percent ?? 0}
-                        unit="cores"
-                        usedIsPercent
-                        hardwareTotal={w.max_cpu != null ? w.total_cpu : undefined}
-                      />
-                      <ResourceBar
-                        label={hasLastKnown ? 'Memory (last known)' : 'Memory'}
-                        total={parseFloat(((w.max_memory_mb ?? w.total_memory_mb) / 1024).toFixed(1))}
-                        reserved={parseFloat((w.allocated_memory_mb / 1024).toFixed(1))}
-                        used={parseFloat(((w.last_heartbeat?.used_memory_mb ?? 0) / 1024).toFixed(1))}
-                        unit="GB"
-                        hardwareTotal={w.max_memory_mb != null ? parseFloat((w.total_memory_mb / 1024).toFixed(1)) : undefined}
-                      />
-                      <DiskSection
-                        usedDiskMb={w.last_heartbeat?.used_disk_mb ?? 0}
-                        totalDiskMb={w.max_disk_mb ?? w.total_disk_mb}
-                        allocatedDiskMb={w.allocated_disk_mb}
-                        diskDetails={w.last_heartbeat?.disk_details ?? w.disk_details ?? []}
-                        expanded={expandedDisks.has(w.worker_id)}
-                        onToggle={() => setExpandedDisks(prev => {
-                          const next = new Set(prev);
-                          if (next.has(w.worker_id)) next.delete(w.worker_id);
-                          else next.add(w.worker_id);
-                          return next;
-                        })}
-                      />
-                    </div>
+                    <ResourceBarsSection w={w} hasLastKnown={hasLastKnown} expandedDisks={expandedDisks} setExpandedDisks={setExpandedDisks} />
                   </div>
                 );
               })()}

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -174,20 +174,20 @@ function ResourceBarsSection({ w, hasLastKnown, expandedDisks, setExpandedDisks 
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <ResourceBar
         label={hasLastKnown ? 'CPU (last known)' : 'CPU'}
-        total={cpuCap}
+        limit={cpuCap}
+        hardwareTotal={w.total_cpu}
         reserved={w.allocated_cpu}
         used={w.last_heartbeat?.used_cpu_percent ?? 0}
         unit="cores"
         usedIsPercent
-        hardwareTotal={cpuCap < w.total_cpu ? w.total_cpu : undefined}
       />
       <ResourceBar
         label={hasLastKnown ? 'Memory (last known)' : 'Memory'}
-        total={parseFloat((memCapMb / 1024).toFixed(1))}
+        limit={parseFloat((memCapMb / 1024).toFixed(1))}
+        hardwareTotal={parseFloat((w.total_memory_mb / 1024).toFixed(1))}
         reserved={parseFloat((w.allocated_memory_mb / 1024).toFixed(1))}
         used={parseFloat(((w.last_heartbeat?.used_memory_mb ?? 0) / 1024).toFixed(1))}
         unit="GB"
-        hardwareTotal={memCapMb < w.total_memory_mb ? parseFloat((w.total_memory_mb / 1024).toFixed(1)) : undefined}
       />
       <DiskSection
         usedDiskMb={w.last_heartbeat?.used_disk_mb ?? 0}

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -164,8 +164,11 @@ function RegisterWorkerModal({
   const [labelInput, setLabelInput] = useState('');
   const [regPriority, setRegPriority] = useState('0');
   const [regMaxCpu, setRegMaxCpu] = useState('');
+  const [regMaxCpuPct, setRegMaxCpuPct] = useState('');
   const [regMaxMemGb, setRegMaxMemGb] = useState('');
+  const [regMaxMemPct, setRegMaxMemPct] = useState('');
   const [regMaxDiskGb, setRegMaxDiskGb] = useState('');
+  const [regMaxDiskPct, setRegMaxDiskPct] = useState('');
 
   const registerMut = useMutation({
     mutationFn: () =>
@@ -176,8 +179,11 @@ function RegisterWorkerModal({
         description: description.trim() || undefined,
         priority: parseInt(regPriority, 10) || 0,
         max_cpu: regMaxCpu !== '' ? parseInt(regMaxCpu, 10) : undefined,
+        max_cpu_percent: regMaxCpuPct !== '' ? parseInt(regMaxCpuPct, 10) : undefined,
         max_memory_mb: regMaxMemGb !== '' ? Math.round(parseFloat(regMaxMemGb) * 1024) : undefined,
+        max_memory_percent: regMaxMemPct !== '' ? parseInt(regMaxMemPct, 10) : undefined,
         max_disk_mb: regMaxDiskGb !== '' ? Math.round(parseFloat(regMaxDiskGb) * 1024) : undefined,
+        max_disk_percent: regMaxDiskPct !== '' ? parseInt(regMaxDiskPct, 10) : undefined,
       }),
     onSuccess: (data) => {
       onSuccess(data);
@@ -282,51 +288,90 @@ function RegisterWorkerModal({
           </div>
           <div className="pt-2 border-t border-slate-700">
             <p className="text-xs text-slate-500 mb-2 font-medium uppercase tracking-wider">Resource Limits</p>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs text-slate-400 mb-1">Priority</label>
-                <input
-                  type="number"
-                  min="0"
-                  value={regPriority}
-                  onChange={(e) => setRegPriority(e.target.value)}
-                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
-              <div>
-                <label className="block text-xs text-slate-400 mb-1">Max CPU (cores)</label>
+            <div className="mb-3">
+              <label className="block text-xs text-slate-400 mb-1">Priority</label>
+              <input
+                type="number"
+                min="0"
+                value={regPriority}
+                onChange={(e) => setRegPriority(e.target.value)}
+                className="w-28 px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="space-y-2">
+              {/* CPU row */}
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs text-slate-400 w-16 shrink-0">Max CPU</span>
                 <input
                   type="number"
                   min="1"
                   value={regMaxCpu}
                   onChange={(e) => setRegMaxCpu(e.target.value)}
-                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
                   placeholder="no limit"
                 />
+                <span className="text-xs text-slate-500">cores</span>
+                <span className="text-xs text-slate-600">or</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="100"
+                  value={regMaxCpuPct}
+                  onChange={(e) => setRegMaxCpuPct(e.target.value)}
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+                <span className="text-xs text-slate-500">%</span>
               </div>
-              <div>
-                <label className="block text-xs text-slate-400 mb-1">Max Memory (GB)</label>
+              {/* Memory row */}
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs text-slate-400 w-16 shrink-0">Max Mem</span>
                 <input
                   type="number"
                   min="0"
                   step="0.1"
                   value={regMaxMemGb}
                   onChange={(e) => setRegMaxMemGb(e.target.value)}
-                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
                   placeholder="no limit"
                 />
+                <span className="text-xs text-slate-500">GB</span>
+                <span className="text-xs text-slate-600">or</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="100"
+                  value={regMaxMemPct}
+                  onChange={(e) => setRegMaxMemPct(e.target.value)}
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+                <span className="text-xs text-slate-500">%</span>
               </div>
-              <div>
-                <label className="block text-xs text-slate-400 mb-1">Max Disk (GB)</label>
+              {/* Disk row */}
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs text-slate-400 w-16 shrink-0">Max Disk</span>
                 <input
                   type="number"
                   min="0"
                   step="0.1"
                   value={regMaxDiskGb}
                   onChange={(e) => setRegMaxDiskGb(e.target.value)}
-                  className="w-full px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
                   placeholder="no limit"
                 />
+                <span className="text-xs text-slate-500">GB</span>
+                <span className="text-xs text-slate-600">or</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="100"
+                  value={regMaxDiskPct}
+                  onChange={(e) => setRegMaxDiskPct(e.target.value)}
+                  className="w-20 px-2 py-1.5 bg-slate-800 border border-slate-600 rounded text-white text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  placeholder="no limit"
+                />
+                <span className="text-xs text-slate-500">%</span>
               </div>
             </div>
           </div>
@@ -519,42 +564,63 @@ function InlineLimitsEditor({
 }) {
   const [priority, setPriority] = useState(String(initial.priority ?? 0));
   const [maxCpu, setMaxCpu] = useState(initial.max_cpu != null ? String(initial.max_cpu) : '');
+  const [maxCpuPct, setMaxCpuPct] = useState(initial.max_cpu_percent != null ? String(initial.max_cpu_percent) : '');
   const [maxMemGb, setMaxMemGb] = useState(
     initial.max_memory_mb != null ? String(parseFloat((initial.max_memory_mb / 1024).toFixed(1))) : '',
   );
+  const [maxMemPct, setMaxMemPct] = useState(initial.max_memory_percent != null ? String(initial.max_memory_percent) : '');
   const [maxDiskGb, setMaxDiskGb] = useState(
     initial.max_disk_mb != null ? String(parseFloat((initial.max_disk_mb / 1024).toFixed(1))) : '',
   );
+  const [maxDiskPct, setMaxDiskPct] = useState(initial.max_disk_percent != null ? String(initial.max_disk_percent) : '');
 
   function save() {
     onSave({
       priority: parseInt(priority, 10) || 0,
       max_cpu: maxCpu !== '' ? parseInt(maxCpu, 10) : null,
+      max_cpu_percent: maxCpuPct !== '' ? parseInt(maxCpuPct, 10) : null,
       max_memory_mb: maxMemGb !== '' ? Math.round(parseFloat(maxMemGb) * 1024) : null,
+      max_memory_percent: maxMemPct !== '' ? parseInt(maxMemPct, 10) : null,
       max_disk_mb: maxDiskGb !== '' ? Math.round(parseFloat(maxDiskGb) * 1024) : null,
+      max_disk_percent: maxDiskPct !== '' ? parseInt(maxDiskPct, 10) : null,
     });
   }
 
-  const inputCls = 'px-2 py-1 text-xs bg-slate-800 border border-slate-600 rounded text-white font-mono w-24 focus:outline-none focus:ring-1 focus:ring-blue-500';
+  const inputCls = 'px-2 py-1 text-xs bg-slate-800 border border-slate-600 rounded text-white font-mono w-20 focus:outline-none focus:ring-1 focus:ring-blue-500';
 
   return (
     <div className="mt-2 space-y-2" aria-label={`Edit limits for worker ${workerId}`}>
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
-        <div>
-          <label className="block text-[10px] text-slate-500 mb-0.5">Priority</label>
-          <input type="number" min="0" value={priority} onChange={(e) => setPriority(e.target.value)} className={inputCls} />
-        </div>
-        <div>
-          <label className="block text-[10px] text-slate-500 mb-0.5">Max CPU (cores)</label>
+      <div className="mb-1.5">
+        <label className="block text-[10px] text-slate-500 mb-0.5">Priority</label>
+        <input type="number" min="0" value={priority} onChange={(e) => setPriority(e.target.value)} className={inputCls} />
+      </div>
+      <div className="space-y-1.5">
+        {/* CPU row */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-[10px] text-slate-500 w-12 shrink-0">Max CPU</span>
           <input type="number" min="1" value={maxCpu} onChange={(e) => setMaxCpu(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">cores</span>
+          <span className="text-[10px] text-slate-600">or</span>
+          <input type="number" min="1" max="100" value={maxCpuPct} onChange={(e) => setMaxCpuPct(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">%</span>
         </div>
-        <div>
-          <label className="block text-[10px] text-slate-500 mb-0.5">Max Memory (GB)</label>
+        {/* Memory row */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-[10px] text-slate-500 w-12 shrink-0">Max Mem</span>
           <input type="number" min="0" step="0.1" value={maxMemGb} onChange={(e) => setMaxMemGb(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">GB</span>
+          <span className="text-[10px] text-slate-600">or</span>
+          <input type="number" min="1" max="100" value={maxMemPct} onChange={(e) => setMaxMemPct(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">%</span>
         </div>
-        <div>
-          <label className="block text-[10px] text-slate-500 mb-0.5">Max Disk (GB)</label>
+        {/* Disk row */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-[10px] text-slate-500 w-12 shrink-0">Max Disk</span>
           <input type="number" min="0" step="0.1" value={maxDiskGb} onChange={(e) => setMaxDiskGb(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">GB</span>
+          <span className="text-[10px] text-slate-600">or</span>
+          <input type="number" min="1" max="100" value={maxDiskPct} onChange={(e) => setMaxDiskPct(e.target.value)} className={inputCls} placeholder="no limit" />
+          <span className="text-[10px] text-slate-500">%</span>
         </div>
       </div>
       <div className="flex gap-2">
@@ -1054,20 +1120,32 @@ export default function WorkersPage() {
               {/* Resource limits inline edit */}
               {canManageWorkers && (
                 <div className="mt-3 pt-3 border-t border-slate-800">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-xs text-slate-500 font-medium">Limits:</span>
-                    {w.max_cpu != null && (
-                      <span className="text-xs text-slate-400">CPU: {w.max_cpu}</span>
-                    )}
-                    {w.max_memory_mb != null && (
-                      <span className="text-xs text-slate-400">Mem: {parseFloat((w.max_memory_mb / 1024).toFixed(1))} GB</span>
-                    )}
-                    {w.max_disk_mb != null && (
-                      <span className="text-xs text-slate-400">Disk: {parseFloat((w.max_disk_mb / 1024).toFixed(1))} GB</span>
-                    )}
-                    {w.max_cpu == null && w.max_memory_mb == null && w.max_disk_mb == null && (
-                      <span className="text-xs text-slate-600 italic">none</span>
-                    )}
+                    {(() => {
+                      const cpuParts = [
+                        w.max_cpu != null ? `${w.max_cpu} cores` : null,
+                        w.max_cpu_percent != null ? `${w.max_cpu_percent}%` : null,
+                      ].filter(Boolean);
+                      const memParts = [
+                        w.max_memory_mb != null ? `${parseFloat((w.max_memory_mb / 1024).toFixed(1))} GB` : null,
+                        w.max_memory_percent != null ? `${w.max_memory_percent}%` : null,
+                      ].filter(Boolean);
+                      const diskParts = [
+                        w.max_disk_mb != null ? `${parseFloat((w.max_disk_mb / 1024).toFixed(1))} GB` : null,
+                        w.max_disk_percent != null ? `${w.max_disk_percent}%` : null,
+                      ].filter(Boolean);
+                      const hasAny = cpuParts.length || memParts.length || diskParts.length;
+                      return hasAny ? (
+                        <>
+                          <span className="text-xs text-slate-400">CPU: {cpuParts.length ? cpuParts.join(' / ') : 'none'}</span>
+                          <span className="text-xs text-slate-400">Mem: {memParts.length ? memParts.join(' / ') : 'none'}</span>
+                          <span className="text-xs text-slate-400">Disk: {diskParts.length ? diskParts.join(' / ') : 'none'}</span>
+                        </>
+                      ) : (
+                        <span className="text-xs text-slate-600 italic">none</span>
+                      );
+                    })()}
                     {editingLimitsId !== w.worker_id && (
                       <button
                         type="button"
@@ -1081,7 +1159,7 @@ export default function WorkersPage() {
                   {editingLimitsId === w.worker_id && (
                     <InlineLimitsEditor
                       workerId={w.worker_id}
-                      initial={{ priority: w.priority, max_cpu: w.max_cpu, max_memory_mb: w.max_memory_mb, max_disk_mb: w.max_disk_mb }}
+                      initial={{ priority: w.priority, max_cpu: w.max_cpu, max_cpu_percent: w.max_cpu_percent, max_memory_mb: w.max_memory_mb, max_memory_percent: w.max_memory_percent, max_disk_mb: w.max_disk_mb, max_disk_percent: w.max_disk_percent }}
                       onSave={(limits) => updateLimitsMut.mutate({ id: w.worker_id, limits })}
                       onCancel={() => setEditingLimitsId(null)}
                       isPending={updateLimitsMut.isPending}

--- a/frontend/src/types/worker.ts
+++ b/frontend/src/types/worker.ts
@@ -62,6 +62,12 @@ export interface Worker {
   max_memory_mb: number | null;
   /** Hard cap on disk in MB (null = no limit) */
   max_disk_mb: number | null;
+  /** Percentage cap on CPU (1-100, null = no limit) */
+  max_cpu_percent: number | null;
+  /** Percentage cap on memory (1-100, null = no limit) */
+  max_memory_percent: number | null;
+  /** Percentage cap on disk (1-100, null = no limit) */
+  max_disk_percent: number | null;
   /** Whether the worker has been approved (set via approve/reject API) */
   approved?: boolean;
   /** ID of the registration token used to register this worker */

--- a/frontend/src/types/worker.ts
+++ b/frontend/src/types/worker.ts
@@ -54,6 +54,14 @@ export interface Worker {
   system_info?: WorkerSystemInfo | null;
   active_groups?: WorkerActiveGroup[];
   labels?: string[];
+  /** Scheduling priority — higher = preferred */
+  priority: number;
+  /** Hard cap on CPU cores (null = use total_cpu) */
+  max_cpu: number | null;
+  /** Hard cap on memory in MB (null = no limit) */
+  max_memory_mb: number | null;
+  /** Hard cap on disk in MB (null = no limit) */
+  max_disk_mb: number | null;
   /** Whether the worker has been approved (set via approve/reject API) */
   approved?: boolean;
   /** ID of the registration token used to register this worker */

--- a/migrations/032_worker_priority_limits.sql
+++ b/migrations/032_worker_priority_limits.sql
@@ -1,11 +1,16 @@
 -- Worker priority + resource limits
 -- Priority: higher = preferred for scheduling. 0 = default.
--- max_*: upper bound chola is allowed to reserve. NULL = use total_* (no limit).
+-- max_*: absolute upper bound. NULL = no limit (use total).
+-- max_*_percent: percentage upper bound (1-100). NULL = no limit.
+-- If both set, effective cap = min(absolute, total * percent / 100).
 
 ALTER TABLE workers ADD COLUMN IF NOT EXISTS priority INT DEFAULT 0;
 ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_cpu INT;
 ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_memory_mb BIGINT;
 ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_disk_mb BIGINT;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_cpu_percent INT;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_memory_percent INT;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_disk_percent INT;
 
 -- Label group priority
 ALTER TABLE label_groups ADD COLUMN IF NOT EXISTS priority INT DEFAULT 0;

--- a/migrations/032_worker_priority_limits.sql
+++ b/migrations/032_worker_priority_limits.sql
@@ -1,0 +1,11 @@
+-- Worker priority + resource limits
+-- Priority: higher = preferred for scheduling. 0 = default.
+-- max_*: upper bound chola is allowed to reserve. NULL = use total_* (no limit).
+
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS priority INT DEFAULT 0;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_cpu INT;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_memory_mb BIGINT;
+ALTER TABLE workers ADD COLUMN IF NOT EXISTS max_disk_mb BIGINT;
+
+-- Label group priority
+ALTER TABLE label_groups ADD COLUMN IF NOT EXISTS priority INT DEFAULT 0;


### PR DESCRIPTION
Closes #12

- Script locking: flock (worker scope) + Redis via gRPC (controller scope)
- Lock key templates: {{WORKER_ID}}-{{REPO_NAME}}-pre, configurable timeout
- Exit code: SIGTERM handler, retry 3x, DB fallback, Failed+exit0 guard
- Disk scheduling uses actual sysinfo usage (not reservation)
- Resource limits: max_cpu/memory/disk (absolute) + percentage, min wins
- Worker priority: higher = preferred, per-worker + per-label-group
- Dual resource bars: reserved against limit, usage against hardware total
- Binary rename: ci-* → chola-*
- Frontend: lock fields, priority badge, limits editor, percentage inputs
- Migrations 031 (locking) + 032 (priority/limits)