### PR TITLE
16: Fix worker allocation counters leak on heartbeat-death

### DIFF
--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -2682,6 +2682,7 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                             format!("Worker {} disconnected (heartbeat timeout)", worker_id);
                         let mut db_updates: Vec<uuid::Uuid> = Vec::new();
 
+                        let mut release_totals = (0u32, 0u64, 0u64);
                         {
                             let mut jg = state_for_hb.job_group_registry.write().await;
                             let (to_migrate, to_fail) = jg.handle_worker_death(worker_id);
@@ -2690,6 +2691,9 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                                 jg.fail_group_jobs(gid, &death_reason);
                                 if let Some(g) = jg.get_mut(gid) {
                                     g.status_reason = Some(death_reason.clone());
+                                    release_totals.0 += g.allocated_resources.cpu;
+                                    release_totals.1 += g.allocated_resources.memory_mb;
+                                    release_totals.2 += g.allocated_resources.disk_mb;
                                 }
                                 state_for_hb.metrics.dec_active_builds();
                                 db_updates.push(*gid);
@@ -2700,6 +2704,19 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                                     "{} groups need migration from dead worker {} (not yet implemented)",
                                     to_migrate.len(),
                                     worker_id
+                                );
+                            }
+                        }
+                        // Release accumulated allocations back to the dead worker so
+                        // its counters reflect reality. Future reconnects / fresh
+                        // registrations rely on this being zero.
+                        if release_totals.0 > 0 || release_totals.1 > 0 || release_totals.2 > 0 {
+                            let mut wr = state_for_hb.worker_registry.write().await;
+                            if let Some(w) = wr.get_mut(worker_id) {
+                                w.release(release_totals.0, release_totals.1, release_totals.2);
+                                info!(
+                                    "Released stale allocation on dead worker {}: cpu={} mem_mb={} disk_mb={}",
+                                    worker_id, release_totals.0, release_totals.1, release_totals.2
                                 );
                             }
                         }

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -2633,6 +2634,61 @@ impl Orchestrator for OrchestratorService {
     }
 }
 
+/// Reconcile each worker's in-memory allocation counters against the actual sum
+/// of their assigned non-terminal groups. Corrects any drift that slips through
+/// normal release paths (e.g. future new code paths or controller restart edge cases).
+async fn reconcile_worker_allocations(state: &Arc<ControllerState>) {
+    // Snapshot worker ids (avoid holding two write locks simultaneously).
+    let worker_ids: Vec<String> = {
+        let wr = state.worker_registry.read().await;
+        wr.all_workers()
+            .iter()
+            .map(|w| w.info.worker_id.clone())
+            .collect()
+    };
+
+    // Compute expected sums per worker from job_group_registry.
+    let expected: HashMap<String, (u32, u64, u64)> = {
+        let jg = state.job_group_registry.read().await;
+        let mut map: HashMap<String, (u32, u64, u64)> = HashMap::new();
+        for wid in &worker_ids {
+            let groups = jg.get_groups_for_worker(wid);
+            let mut sum = (0u32, 0u64, 0u64);
+            for g in groups {
+                if !g.state.is_terminal() {
+                    sum.0 += g.allocated_resources.cpu;
+                    sum.1 += g.allocated_resources.memory_mb;
+                    sum.2 += g.allocated_resources.disk_mb;
+                }
+            }
+            map.insert(wid.clone(), sum);
+        }
+        map
+    };
+
+    // Apply correction under write lock if drift detected.
+    let mut wr = state.worker_registry.write().await;
+    for wid in &worker_ids {
+        let Some(w) = wr.get_mut(wid) else {
+            continue;
+        };
+        let expected_sum = expected.get(wid).copied().unwrap_or_default();
+        let actual_sum = (w.allocated_cpu, w.allocated_memory_mb, w.allocated_disk_mb);
+        if actual_sum != expected_sum {
+            tracing::warn!(
+                worker_id = %wid,
+                actual_cpu = actual_sum.0, expected_cpu = expected_sum.0,
+                actual_mem = actual_sum.1, expected_mem = expected_sum.1,
+                actual_disk = actual_sum.2, expected_disk = expected_sum.2,
+                "Worker allocation drift detected; correcting"
+            );
+            w.allocated_cpu = expected_sum.0;
+            w.allocated_memory_mb = expected_sum.1;
+            w.allocated_disk_mb = expected_sum.2;
+        }
+    }
+}
+
 /// Start the gRPC server.
 ///
 /// Accepts the fully-constructed shared `ControllerState` so both the gRPC and
@@ -2769,6 +2825,20 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                 if count > 0 {
                     warn!("Cancelled {} orphaned jobs", count);
                 }
+            }
+        });
+    }
+
+    // ── Worker allocation reconciler — every 60 seconds ──────────────────────
+    {
+        let state_for_recon = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+            // First tick fires immediately; skip it so we don't race with startup.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                reconcile_worker_allocations(&state_for_recon).await;
             }
         });
     }


### PR DESCRIPTION
Closes #16 

## Summary

  - `WorkerState.allocated_cpu / allocated_memory_mb / allocated_disk_mb` are flat counters used as the O(1) capacity gate during reservation. They are also surfaced by `/api/v1/workers`.
  - The heartbeat-timeout death path in `grpc_server.rs` clears the PG row and the Redis key but never deducts these counters, so they leak until controller restart and block subsequent reservations.

  - Fix sums each failed group's `allocated_resources` during cleanup and calls `WorkerState::release(...)`.
  - Adds a 60 s background reconciler that recomputes expected counters from `job_group_registry` and corrects any drift (logged as `Worker allocation drift detected; correcting`). Self-heals existing stuck workers without a con
troller restart.