### PR TITLE
24: Reservation-driven multi-stage builds + build-detail UX

### DIFF
--- a/crates/ci-controller/src/api/job_group_handlers.rs
+++ b/crates/ci-controller/src/api/job_group_handlers.rs
@@ -261,8 +261,12 @@ pub async fn get_one(
         String::new()
     };
 
-    // Look up reserved stages from stage_configs for this repo
-    let reserved_stages: Vec<String> = if let Some(rid) = group.repo_id {
+    // The granted stage manifest (set at reservation time, post silent-
+    // filter). Empty for legacy rows from before migration 034 — fall
+    // back to the repo's full stage_configs list for those.
+    let reserved_stages: Vec<String> = if !group.reserved_stages.is_empty() {
+        group.reserved_stages.clone()
+    } else if let Some(rid) = group.repo_id {
         storage
             .get_stage_configs_for_repo(rid)
             .await
@@ -273,6 +277,10 @@ pub async fn get_one(
     } else {
         Vec::new()
     };
+
+    // Stages that have a submitted job — for "X of Y" progress UI. Order
+    // matches the jobs list (creation order).
+    let submitted_stages: Vec<String> = jobs.iter().map(|j| j.stage_name.clone()).collect();
 
     // Look up allocated resources from in-memory registry
     let alloc = {
@@ -508,6 +516,7 @@ pub async fn get_one(
         "state": group.state.to_string(),
         "status_reason": group.status_reason,
         "reserved_stages": reserved_stages,
+        "submitted_stages": submitted_stages,
         "allocated_resources": alloc_json,
         "created_at": group.created_at.to_rfc3339(),
         "updated_at": group.updated_at.to_rfc3339(),

--- a/crates/ci-controller/src/api/job_group_handlers.rs
+++ b/crates/ci-controller/src/api/job_group_handlers.rs
@@ -5,13 +5,61 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::warn;
 use uuid::Uuid;
 
 use ci_core::models::job_group::JobGroupState;
-use ci_core::proto::orchestrator::ReserveWorkerRequest;
+use ci_core::proto::orchestrator::{ReserveWorkerRequest, ReserveWorkerResponse};
+
+// ── REST response shape for POST /api/v1/job-groups ──────────────────────────
+//
+// We don't return the proto type directly — proto3 scalars can't be `null`,
+// and Jenkins/clients are easier to write against `Option<String>` than
+// against empty-string-means-absent semantics.
+
+#[derive(Serialize)]
+struct TriggerResponse {
+    /// Reservation id. `null` when nothing was reserved (all-unknown, no workers, etc.).
+    job_group_id: Option<String>,
+    /// Worker that owns the reservation. `null` when nothing was reserved.
+    worker_id: Option<String>,
+    /// Stages the controller will actually run (granted subset).
+    stages: Vec<StageInfoJson>,
+    /// Requested stage names that aren't configured for this repo and were
+    /// silently dropped. Always present (possibly `[]`) so callers don't have
+    /// to check field existence.
+    skipped_stages: Vec<String>,
+    success: bool,
+    /// Human-readable summary. Safe to surface in the Jenkins console.
+    message: String,
+}
+
+#[derive(Serialize)]
+struct StageInfoJson {
+    stage_name: String,
+}
+
+impl TriggerResponse {
+    fn build(resp: ReserveWorkerResponse, dropped: Vec<String>) -> Self {
+        let to_opt = |s: String| (!s.is_empty()).then_some(s);
+        Self {
+            job_group_id: to_opt(resp.job_group_id),
+            worker_id: to_opt(resp.worker_id),
+            stages: resp
+                .stages
+                .into_iter()
+                .map(|s| StageInfoJson {
+                    stage_name: s.stage_name,
+                })
+                .collect(),
+            skipped_stages: dropped,
+            success: resp.success,
+            message: resp.message,
+        }
+    }
+}
 
 use crate::auth::middleware::AuthUser;
 use crate::grpc_server::do_reserve_worker;
@@ -610,7 +658,7 @@ pub async fn trigger(
         idempotency_key: body.idempotency_key.clone().unwrap_or_default(),
     };
 
-    let resp = do_reserve_worker(&state, &req)
+    let (resp, dropped) = do_reserve_worker(&state, &req)
         .await
         .map_err(|e| ApiError::Internal(e.message().to_string()))?;
 
@@ -618,18 +666,11 @@ pub async fn trigger(
         return Err(ApiError::Conflict(resp.message));
     }
 
-    let stages: Vec<Value> = resp
-        .stages
-        .iter()
-        .map(|s| json!({"stage_name": s.stage_name}))
-        .collect();
-
-    Ok(Json(json!({
-        "job_group_id": resp.job_group_id,
-        "worker_id": resp.worker_id,
-        "stages": stages,
-        "message": resp.message,
-    })))
+    // Serializing an owned struct with derived Serialize is infallible in
+    // practice — no map-key gymnastics, no streaming IO.
+    let value = serde_json::to_value(TriggerResponse::build(resp, dropped))
+        .expect("TriggerResponse serializes cleanly");
+    Ok(Json(value))
 }
 
 /// POST /api/v1/job-groups/:id/retry  — re-run a failed/cancelled build
@@ -680,7 +721,9 @@ pub async fn retry(
         idempotency_key: String::new(),
     };
 
-    let resp = do_reserve_worker(&state, &req)
+    // Retry never sends unconfigured stages (we copy from existing jobs), so
+    // `dropped` is structurally always empty here — drop it.
+    let (resp, _dropped) = do_reserve_worker(&state, &req)
         .await
         .map_err(|e| ApiError::Internal(e.message().to_string()))?;
 

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -2580,6 +2580,7 @@ impl Orchestrator for OrchestratorService {
                 pr_number: None,
                 idempotency_key: None,
                 allocated_resources: ci_core::models::job_group::AllocatedResources::default(),
+                reserved_stages: Vec::new(),
                 status_reason: None,
                 created_at: now,
                 updated_at: now,

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -1103,6 +1103,9 @@ pub async fn do_reserve_worker(
         memory_mb: needed_memory,
         disk_mb: needed_disk,
     };
+    // Persist the granted (filtered) stage list so check_group_completion
+    // can gate Success on "every reserved stage has a terminal job."
+    group.reserved_stages = effective_stages.clone();
     group.updated_at = chrono::Utc::now();
 
     // Build stage info from the FILTERED stage list — never expose unknown

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -710,35 +710,40 @@ async fn compute_resource_needs(
 /// with enough available capacity. Multiple builds can share a worker when
 /// resources allow. Falls back to whole-worker reservation when stages have
 /// no resource requirements configured.
+/// Returns `(response, dropped_stages)`. `dropped_stages` is the list of
+/// requested stage names that aren't configured for the repo — surfaced
+/// separately so the REST handler can emit a structured `skipped_stages`
+/// field. gRPC callers can ignore `.1`.
 pub async fn do_reserve_worker(
     state: &Arc<ControllerState>,
     req: &ReserveWorkerRequest,
-) -> Result<ReserveWorkerResponse, Status> {
+) -> Result<(ReserveWorkerResponse, Vec<String>), Status> {
     // Generate group_id upfront so Redis lock references it
     let group_id = uuid::Uuid::new_v4();
 
-    // ── Early validation, hoisted above worker selection ─────────────────
-    // Looking up the repo, validating stage names, fetching the dependency
-    // map, and consulting the idempotency cache must all happen BEFORE a
-    // worker is selected. Otherwise a reservation can hold a worker while
-    // the request turns out to be invalid (or already cached) and we leak
-    // resources until the group times out.
-
-    // Look up repo by name — must exist in DB
+    // ── Early validation: repo + stage filtering ─────────────────────────
+    // Look up the repo, then filter requested stages against its
+    // stage_configs BEFORE any worker selection. This way we never reserve
+    // a worker just to discover the request is unactionable, and the
+    // all-unknown short-circuit doesn't depend on workers being available
+    // at all.
     let (repo_id, max_concurrent, cancel_superseded) = if let Some(storage) = &state.storage {
         match storage.get_repo_by_name(&req.repo_name).await {
             Ok(Some(repo)) => (repo.id, repo.max_concurrent_builds, repo.cancel_superseded),
             Ok(None) => {
-                return Ok(ReserveWorkerResponse {
-                    job_group_id: String::new(),
-                    worker_id: String::new(),
-                    stages: Vec::new(),
-                    success: false,
-                    message: format!(
-                        "Repo '{}' not found — create it in the DB first",
-                        req.repo_name
-                    ),
-                });
+                return Ok((
+                    ReserveWorkerResponse {
+                        job_group_id: String::new(),
+                        worker_id: String::new(),
+                        stages: Vec::new(),
+                        success: false,
+                        message: format!(
+                            "Repo '{}' not found — create it in the DB first",
+                            req.repo_name
+                        ),
+                    },
+                    Vec::new(),
+                ));
             }
             Err(e) => {
                 warn!("Failed to lookup repo {}: {}", req.repo_name, e);
@@ -750,13 +755,9 @@ pub async fn do_reserve_worker(
     };
 
     // Silent-filter requested stages against the repo's stage_configs.
-    //
-    // The Jenkinsfile sends a wide candidate list (e.g.
-    // [checkout-scm, vira-ci, gitleaks]) where some names may be Jenkins-
-    // managed steps with no stage_config (checkout-scm) or stages that
-    // will be configured later. We drop the unknown ones and continue
-    // with the known subset; the dropped names are surfaced in the
-    // response message so Jenkins console shows them.
+    // Unknown stage names are dropped; the dropped list is propagated to
+    // the REST layer via the `skipped_stages` field. Jenkins-managed steps
+    // like `checkout-scm` are EXPECTED to land here.
     let (effective_stages, dropped_stages): (Vec<String>, Vec<String>) = if req.stages.is_empty() {
         (Vec::new(), Vec::new())
     } else if let Some(storage) = &state.storage {
@@ -784,22 +785,28 @@ pub async fn do_reserve_worker(
 
     // All-unknown short-circuit. Caller asked for stages but none are
     // configured — return success with no reservation so Jenkins falls
-    // back to Cloud cleanly. NO worker held, NO DB row, NO Redis key.
+    // back to Cloud. NO worker held, NO DB row, NO Redis key.
     if !req.stages.is_empty() && effective_stages.is_empty() {
-        return Ok(ReserveWorkerResponse {
-            job_group_id: String::new(),
-            worker_id: String::new(),
-            stages: Vec::new(),
-            success: true,
-            message: format!(
-                "No configured stages for repo '{}'. Skipped: {}",
-                req.repo_name,
-                dropped_stages.join(", ")
-            ),
-        });
+        let msg = format!(
+            "No configured stages for repo '{}'. Skipped: {}",
+            req.repo_name,
+            dropped_stages.join(", ")
+        );
+        return Ok((
+            ReserveWorkerResponse {
+                job_group_id: String::new(),
+                worker_id: String::new(),
+                stages: Vec::new(),
+                success: true,
+                message: msg,
+            },
+            dropped_stages,
+        ));
     }
 
-    // Fetch stage dependency map for DAG validation and StageInfo enrichment
+    // Fetch stage dependency map up-front — needed both for StageInfo
+    // construction in the idempotency cache return path AND for the DAG
+    // validation that runs later. Computed once, used in both places.
     let stage_deps: std::collections::HashMap<String, Vec<String>> =
         if let Some(storage) = &state.storage {
             storage
@@ -810,7 +817,7 @@ pub async fn do_reserve_worker(
             std::collections::HashMap::new()
         };
 
-    // Helper: build StageInfo with depends_on from the DB map
+    // Helper: build StageInfo enriched with depends_on from the DB map.
     let build_stage_info = |name: &str| -> ci_core::proto::orchestrator::StageInfo {
         let deps = stage_deps.get(name).cloned().unwrap_or_default();
         ci_core::proto::orchestrator::StageInfo {
@@ -826,10 +833,10 @@ pub async fn do_reserve_worker(
         }
     };
 
-    // Idempotency: if key provided, return existing group with same key.
-    // Done BEFORE worker selection so a retry with the same key returns the
-    // cached group even when workers are tight, instead of failing fresh
-    // worker selection.
+    // Idempotency cache lookup — must run BEFORE worker selection so a retry
+    // with the same key returns the cached group without consuming a fresh
+    // worker reservation. If workers are tight, the original reservation is
+    // still the right answer.
     if !req.idempotency_key.is_empty() {
         if let Some(storage) = &state.storage {
             if let Ok(Some(existing)) = storage.find_by_idempotency_key(&req.idempotency_key).await
@@ -849,20 +856,21 @@ pub async fn do_reserve_worker(
                         "Returning existing group {} for idempotency_key={}",
                         existing.id, req.idempotency_key
                     );
-                    // Report only the granted (effective) subset, never the
-                    // dropped stage names.
                     let stages = effective_stages
                         .iter()
                         .map(|n| build_stage_info(n))
                         .collect();
-                    return Ok(ReserveWorkerResponse {
-                        job_group_id: existing.id.to_string(),
-                        worker_id: existing.reserved_worker_id.unwrap_or_default(),
-                        stages,
-                        success: true,
-                        message: "Existing active group returned (idempotency key match)"
-                            .to_string(),
-                    });
+                    return Ok((
+                        ReserveWorkerResponse {
+                            job_group_id: existing.id.to_string(),
+                            worker_id: existing.reserved_worker_id.unwrap_or_default(),
+                            stages,
+                            success: true,
+                            message: "Existing active group returned (idempotency key match)"
+                                .to_string(),
+                        },
+                        dropped_stages.clone(),
+                    ));
                 } else {
                     warn!(
                         "Existing group {} (key={}) has disconnected worker, creating new reservation",
@@ -872,6 +880,7 @@ pub async fn do_reserve_worker(
             }
         }
     }
+    // No key or no match -- create new group (no implicit dedup)
 
     // Compute resource requirements from stage_configs
     let (needed_cpu, needed_memory, needed_disk) = compute_resource_needs(state, req).await;
@@ -882,13 +891,16 @@ pub async fn do_reserve_worker(
         let connected = registry.connected_workers();
 
         if connected.is_empty() {
-            return Ok(ReserveWorkerResponse {
-                job_group_id: String::new(),
-                worker_id: String::new(),
-                stages: Vec::new(),
-                success: false,
-                message: "No connected workers available".to_string(),
-            });
+            return Ok((
+                ReserveWorkerResponse {
+                    job_group_id: String::new(),
+                    worker_id: String::new(),
+                    stages: Vec::new(),
+                    success: false,
+                    message: "No connected workers available".to_string(),
+                },
+                Vec::new(),
+            ));
         }
 
         // Filter by available resources (0 needed = no resource filter)
@@ -909,13 +921,16 @@ pub async fn do_reserve_worker(
     // worker_registry lock dropped here
 
     if candidate_ids.is_empty() {
-        return Ok(ReserveWorkerResponse {
-            job_group_id: String::new(),
-            worker_id: String::new(),
-            stages: Vec::new(),
-            success: false,
-            message: "No workers with sufficient resources available".to_string(),
-        });
+        return Ok((
+            ReserveWorkerResponse {
+                job_group_id: String::new(),
+                worker_id: String::new(),
+                stages: Vec::new(),
+                success: false,
+                message: "No workers with sufficient resources available".to_string(),
+            },
+            Vec::new(),
+        ));
     }
 
     // Allocate resources atomically via WorkerState::allocate() under write lock.
@@ -955,13 +970,16 @@ pub async fn do_reserve_worker(
     let worker_id = match worker_id {
         Some(id) => id,
         None => {
-            return Ok(ReserveWorkerResponse {
-                job_group_id: String::new(),
-                worker_id: String::new(),
-                stages: Vec::new(),
-                success: false,
-                message: "No workers with sufficient resources available".to_string(),
-            });
+            return Ok((
+                ReserveWorkerResponse {
+                    job_group_id: String::new(),
+                    worker_id: String::new(),
+                    stages: Vec::new(),
+                    success: false,
+                    message: "No workers with sufficient resources available".to_string(),
+                },
+                Vec::new(),
+            ));
         }
     };
 
@@ -1002,8 +1020,8 @@ pub async fn do_reserve_worker(
         }
     }
 
-    // (Repo lookup + stage validation are now done at the top of this
-    // function, above worker selection — see the "Early validation" block.)
+    // (Repo lookup, stage filter, and all-unknown short-circuit are now
+    // done at the top of the function — see the "Early validation" block.)
 
     // Enforce concurrency limits
     if max_concurrent > 0 {
@@ -1051,15 +1069,19 @@ pub async fn do_reserve_worker(
         }
     }
 
-    // (stage_deps + build_stage_info + idempotency lookup are now done at
-    // the top of this function — see the "Early validation" block.) Run the
-    // DAG cycle check here using the hoisted stage_deps map.
+    // (stage_deps + build_stage_info closure are now defined earlier, above
+    // the idempotency cache lookup.) Validate the DAG here using the same
+    // map.
     if let Err(cycle_node) = dag::validate_dag(&stage_deps) {
         return Err(Status::invalid_argument(format!(
             "Stage dependency cycle detected involving '{}'",
             cycle_node
         )));
     }
+
+    // (Idempotency cache lookup is now done above, before worker selection —
+    // a retry with the same key must return the cached group without
+    // consuming worker resources for a fresh selection.)
 
     // Redis lock acquired (or no Redis) -- now create the in-memory group
     let mut group = ci_core::models::job_group::JobGroup::new(
@@ -1122,13 +1144,16 @@ pub async fn do_reserve_worker(
         )
     };
 
-    Ok(ReserveWorkerResponse {
-        job_group_id: group_id.to_string(),
-        worker_id,
-        stages: stage_infos,
-        success: true,
-        message,
-    })
+    Ok((
+        ReserveWorkerResponse {
+            job_group_id: group_id.to_string(),
+            worker_id,
+            stages: stage_infos,
+            success: true,
+            message,
+        },
+        dropped_stages,
+    ))
 }
 
 /// Core logic for the `submit_stage` RPC.
@@ -2874,7 +2899,9 @@ impl Orchestrator for OrchestratorService {
             req.repo_name, req.branch, req.stages
         );
 
-        let response = do_reserve_worker(&self.state, &req).await?;
+        // gRPC contract is the proto response only — drop the dropped_stages
+        // side channel (REST-only enrichment).
+        let (response, _dropped) = do_reserve_worker(&self.state, &req).await?;
         Ok(Response::new(response))
     }
 
@@ -3396,13 +3423,13 @@ pub async fn run(state: Arc<ControllerState>) -> anyhow::Result<()> {
                         idempotency_key: String::new(),
                     };
                     match do_reserve_worker(&state_cron, &req).await {
-                        Ok(resp) if resp.success => {
+                        Ok((resp, _dropped)) if resp.success => {
                             info!(
                                 "Cron: reserved worker {} for group {} (schedule {})",
                                 resp.worker_id, resp.job_group_id, schedule.id
                             );
                         }
-                        Ok(resp) => {
+                        Ok((resp, _dropped)) => {
                             warn!(
                                 "Cron: reserve failed for schedule {}: {}",
                                 schedule.id, resp.message

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -717,6 +717,132 @@ pub async fn do_reserve_worker(
     // Generate group_id upfront so Redis lock references it
     let group_id = uuid::Uuid::new_v4();
 
+    // ── Early validation, hoisted above worker selection ─────────────────
+    // Looking up the repo, validating stage names, fetching the dependency
+    // map, and consulting the idempotency cache must all happen BEFORE a
+    // worker is selected. Otherwise a reservation can hold a worker while
+    // the request turns out to be invalid (or already cached) and we leak
+    // resources until the group times out.
+
+    // Look up repo by name — must exist in DB
+    let (repo_id, max_concurrent, cancel_superseded) = if let Some(storage) = &state.storage {
+        match storage.get_repo_by_name(&req.repo_name).await {
+            Ok(Some(repo)) => (repo.id, repo.max_concurrent_builds, repo.cancel_superseded),
+            Ok(None) => {
+                return Ok(ReserveWorkerResponse {
+                    job_group_id: String::new(),
+                    worker_id: String::new(),
+                    stages: Vec::new(),
+                    success: false,
+                    message: format!(
+                        "Repo '{}' not found — create it in the DB first",
+                        req.repo_name
+                    ),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to lookup repo {}: {}", req.repo_name, e);
+                (uuid::Uuid::new_v4(), 0, false)
+            }
+        }
+    } else {
+        (uuid::Uuid::new_v4(), 0, false) // no DB — in-memory only
+    };
+
+    // Validate requested stages exist in DB
+    if !req.stages.is_empty() {
+        if let Some(storage) = &state.storage {
+            let configs = storage
+                .get_stage_configs_for_repo(repo_id)
+                .await
+                .unwrap_or_default();
+            let known: std::collections::HashSet<&str> =
+                configs.iter().map(|c| c.stage_name.as_str()).collect();
+            let unknown: Vec<&str> = req
+                .stages
+                .iter()
+                .filter(|s| !s.is_empty() && !known.contains(s.as_str()))
+                .map(|s| s.as_str())
+                .collect();
+            if !unknown.is_empty() {
+                return Err(Status::invalid_argument(format!(
+                    "Unknown stages for repo '{}': {}",
+                    req.repo_name,
+                    unknown.join(", ")
+                )));
+            }
+        }
+    }
+
+    // Fetch stage dependency map for DAG validation and StageInfo enrichment
+    let stage_deps: std::collections::HashMap<String, Vec<String>> =
+        if let Some(storage) = &state.storage {
+            storage
+                .get_stage_dependencies(repo_id)
+                .await
+                .unwrap_or_default()
+        } else {
+            std::collections::HashMap::new()
+        };
+
+    // Helper: build StageInfo with depends_on from the DB map
+    let build_stage_info = |name: &str| -> ci_core::proto::orchestrator::StageInfo {
+        let deps = stage_deps.get(name).cloned().unwrap_or_default();
+        ci_core::proto::orchestrator::StageInfo {
+            stage_name: name.to_string(),
+            command: String::new(),
+            required_cpu: 0,
+            required_memory_mb: 0,
+            required_disk_mb: 0,
+            max_duration_secs: 0,
+            parallel_group: String::new(),
+            job_type: "common".to_string(),
+            depends_on: deps,
+        }
+    };
+
+    // Idempotency: if key provided, return existing group with same key.
+    // Done BEFORE worker selection so a retry with the same key returns the
+    // cached group even when workers are tight, instead of failing fresh
+    // worker selection.
+    if !req.idempotency_key.is_empty() {
+        if let Some(storage) = &state.storage {
+            if let Ok(Some(existing)) = storage.find_by_idempotency_key(&req.idempotency_key).await
+            {
+                let worker_connected = {
+                    let wr = state.worker_registry.read().await;
+                    existing
+                        .reserved_worker_id
+                        .as_ref()
+                        .and_then(|wid| wr.get(wid))
+                        .map(|w| w.status == ci_core::models::worker::WorkerStatus::Connected)
+                        .unwrap_or(false)
+                };
+
+                if worker_connected {
+                    info!(
+                        "Returning existing group {} for idempotency_key={}",
+                        existing.id, req.idempotency_key
+                    );
+                    let stages = req.stages.iter().map(|n| build_stage_info(n)).collect();
+                    return Ok(ReserveWorkerResponse {
+                        job_group_id: existing.id.to_string(),
+                        worker_id: existing.reserved_worker_id.unwrap_or_default(),
+                        stages,
+                        success: true,
+                        message: "Existing active group returned (idempotency key match)"
+                            .to_string(),
+                    });
+                } else {
+                    warn!(
+                        "Existing group {} (key={}) has disconnected worker, creating new reservation",
+                        existing.id, req.idempotency_key
+                    );
+                }
+            }
+        }
+    }
+
     // Compute resource requirements from stage_configs
     let (needed_cpu, needed_memory, needed_disk) = compute_resource_needs(state, req).await;
 
@@ -846,55 +972,8 @@ pub async fn do_reserve_worker(
         }
     }
 
-    // Look up repo by name — must exist in DB
-    let (repo_id, max_concurrent, cancel_superseded) = if let Some(storage) = &state.storage {
-        match storage.get_repo_by_name(&req.repo_name).await {
-            Ok(Some(repo)) => (repo.id, repo.max_concurrent_builds, repo.cancel_superseded),
-            Ok(None) => {
-                return Ok(ReserveWorkerResponse {
-                    job_group_id: String::new(),
-                    worker_id: String::new(),
-                    stages: Vec::new(),
-                    success: false,
-                    message: format!(
-                        "Repo '{}' not found — create it in the DB first",
-                        req.repo_name
-                    ),
-                });
-            }
-            Err(e) => {
-                warn!("Failed to lookup repo {}: {}", req.repo_name, e);
-                (uuid::Uuid::new_v4(), 0, false)
-            }
-        }
-    } else {
-        (uuid::Uuid::new_v4(), 0, false) // no DB — in-memory only
-    };
-
-    // Validate requested stages exist in DB
-    if !req.stages.is_empty() {
-        if let Some(storage) = &state.storage {
-            let configs = storage
-                .get_stage_configs_for_repo(repo_id)
-                .await
-                .unwrap_or_default();
-            let known: std::collections::HashSet<&str> =
-                configs.iter().map(|c| c.stage_name.as_str()).collect();
-            let unknown: Vec<&str> = req
-                .stages
-                .iter()
-                .filter(|s| !s.is_empty() && !known.contains(s.as_str()))
-                .map(|s| s.as_str())
-                .collect();
-            if !unknown.is_empty() {
-                return Err(Status::invalid_argument(format!(
-                    "Unknown stages for repo '{}': {}",
-                    req.repo_name,
-                    unknown.join(", ")
-                )));
-            }
-        }
-    }
+    // (Repo lookup + stage validation are now done at the top of this
+    // function, above worker selection — see the "Early validation" block.)
 
     // Enforce concurrency limits
     if max_concurrent > 0 {
@@ -942,80 +1021,15 @@ pub async fn do_reserve_worker(
         }
     }
 
-    // Fetch stage dependency map for DAG validation and StageInfo enrichment
-    let stage_deps: std::collections::HashMap<String, Vec<String>> =
-        if let Some(storage) = &state.storage {
-            storage
-                .get_stage_dependencies(repo_id)
-                .await
-                .unwrap_or_default()
-        } else {
-            std::collections::HashMap::new()
-        };
-
-    // Validate DAG — reject reservation if stages form a cycle
+    // (stage_deps + build_stage_info + idempotency lookup are now done at
+    // the top of this function — see the "Early validation" block.) Run the
+    // DAG cycle check here using the hoisted stage_deps map.
     if let Err(cycle_node) = dag::validate_dag(&stage_deps) {
         return Err(Status::invalid_argument(format!(
             "Stage dependency cycle detected involving '{}'",
             cycle_node
         )));
     }
-
-    // Helper: build StageInfo with depends_on from the DB map
-    let build_stage_info = |name: &str| -> ci_core::proto::orchestrator::StageInfo {
-        let deps = stage_deps.get(name).cloned().unwrap_or_default();
-        ci_core::proto::orchestrator::StageInfo {
-            stage_name: name.to_string(),
-            command: String::new(),
-            required_cpu: 0,
-            required_memory_mb: 0,
-            required_disk_mb: 0,
-            max_duration_secs: 0,
-            parallel_group: String::new(),
-            job_type: "common".to_string(),
-            depends_on: deps,
-        }
-    };
-
-    // Idempotency: if key provided, return existing group with same key
-    if !req.idempotency_key.is_empty() {
-        if let Some(storage) = &state.storage {
-            if let Ok(Some(existing)) = storage.find_by_idempotency_key(&req.idempotency_key).await
-            {
-                let worker_connected = {
-                    let wr = state.worker_registry.read().await;
-                    existing
-                        .reserved_worker_id
-                        .as_ref()
-                        .and_then(|wid| wr.get(wid))
-                        .map(|w| w.status == ci_core::models::worker::WorkerStatus::Connected)
-                        .unwrap_or(false)
-                };
-
-                if worker_connected {
-                    info!(
-                        "Returning existing group {} for idempotency_key={}",
-                        existing.id, req.idempotency_key
-                    );
-                    let stages = req.stages.iter().map(|n| build_stage_info(n)).collect();
-                    return Ok(ReserveWorkerResponse {
-                        job_group_id: existing.id.to_string(),
-                        worker_id: existing.reserved_worker_id.unwrap_or_default(),
-                        stages,
-                        success: true,
-                        message: "Existing active group returned (idempotency key match)"
-                            .to_string(),
-                    });
-                } else {
-                    warn!(
-                        "Existing group {} (key={}) has disconnected worker, creating new reservation",
-                        existing.id, req.idempotency_key
-                    );
-                }
-            }
-        }
-    }
-    // No key or no match -- create new group (no implicit dedup)
 
     // Redis lock acquired (or no Redis) -- now create the in-memory group
     let mut group = ci_core::models::job_group::JobGroup::new(

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -749,29 +749,54 @@ pub async fn do_reserve_worker(
         (uuid::Uuid::new_v4(), 0, false) // no DB — in-memory only
     };
 
-    // Validate requested stages exist in DB
-    if !req.stages.is_empty() {
-        if let Some(storage) = &state.storage {
-            let configs = storage
-                .get_stage_configs_for_repo(repo_id)
-                .await
-                .unwrap_or_default();
-            let known: std::collections::HashSet<&str> =
-                configs.iter().map(|c| c.stage_name.as_str()).collect();
-            let unknown: Vec<&str> = req
-                .stages
-                .iter()
-                .filter(|s| !s.is_empty() && !known.contains(s.as_str()))
-                .map(|s| s.as_str())
-                .collect();
-            if !unknown.is_empty() {
-                return Err(Status::invalid_argument(format!(
-                    "Unknown stages for repo '{}': {}",
-                    req.repo_name,
-                    unknown.join(", ")
-                )));
-            }
-        }
+    // Silent-filter requested stages against the repo's stage_configs.
+    //
+    // The Jenkinsfile sends a wide candidate list (e.g.
+    // [checkout-scm, vira-ci, gitleaks]) where some names may be Jenkins-
+    // managed steps with no stage_config (checkout-scm) or stages that
+    // will be configured later. We drop the unknown ones and continue
+    // with the known subset; the dropped names are surfaced in the
+    // response message so Jenkins console shows them.
+    let (effective_stages, dropped_stages): (Vec<String>, Vec<String>) = if req.stages.is_empty() {
+        (Vec::new(), Vec::new())
+    } else if let Some(storage) = &state.storage {
+        let configs = storage
+            .get_stage_configs_for_repo(repo_id)
+            .await
+            .unwrap_or_default();
+        let known: std::collections::HashSet<&str> =
+            configs.iter().map(|c| c.stage_name.as_str()).collect();
+        req.stages
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .partition(|s| known.contains(s.as_str()))
+    } else {
+        (req.stages.clone(), Vec::new())
+    };
+
+    if !dropped_stages.is_empty() {
+        info!(
+            "Reservation: skipping unconfigured stages {:?} for repo '{}'",
+            dropped_stages, req.repo_name
+        );
+    }
+
+    // All-unknown short-circuit. Caller asked for stages but none are
+    // configured — return success with no reservation so Jenkins falls
+    // back to Cloud cleanly. NO worker held, NO DB row, NO Redis key.
+    if !req.stages.is_empty() && effective_stages.is_empty() {
+        return Ok(ReserveWorkerResponse {
+            job_group_id: String::new(),
+            worker_id: String::new(),
+            stages: Vec::new(),
+            success: true,
+            message: format!(
+                "No configured stages for repo '{}'. Skipped: {}",
+                req.repo_name,
+                dropped_stages.join(", ")
+            ),
+        });
     }
 
     // Fetch stage dependency map for DAG validation and StageInfo enrichment
@@ -824,7 +849,12 @@ pub async fn do_reserve_worker(
                         "Returning existing group {} for idempotency_key={}",
                         existing.id, req.idempotency_key
                     );
-                    let stages = req.stages.iter().map(|n| build_stage_info(n)).collect();
+                    // Report only the granted (effective) subset, never the
+                    // dropped stage names.
+                    let stages = effective_stages
+                        .iter()
+                        .map(|n| build_stage_info(n))
+                        .collect();
                     return Ok(ReserveWorkerResponse {
                         job_group_id: existing.id.to_string(),
                         worker_id: existing.reserved_worker_id.unwrap_or_default(),
@@ -1053,9 +1083,12 @@ pub async fn do_reserve_worker(
     };
     group.updated_at = chrono::Utc::now();
 
-    // Build stage info from request stages
-    let stage_infos: Vec<ci_core::proto::orchestrator::StageInfo> =
-        req.stages.iter().map(|n| build_stage_info(n)).collect();
+    // Build stage info from the FILTERED stage list — never expose unknown
+    // stage names to the caller as "reserved".
+    let stage_infos: Vec<ci_core::proto::orchestrator::StageInfo> = effective_stages
+        .iter()
+        .map(|n| build_stage_info(n))
+        .collect();
 
     // Persist job group to PostgreSQL (clone before add_group takes ownership)
     if let Some(storage) = &state.storage {
@@ -1079,12 +1112,22 @@ pub async fn do_reserve_worker(
         worker_id, group_id, req.repo_name, req.branch
     );
 
+    let message = if dropped_stages.is_empty() {
+        "Worker reserved successfully".to_string()
+    } else {
+        format!(
+            "Worker reserved successfully. Skipped (not configured for repo '{}'): {}",
+            req.repo_name,
+            dropped_stages.join(", ")
+        )
+    };
+
     Ok(ReserveWorkerResponse {
         job_group_id: group_id.to_string(),
         worker_id,
         stages: stage_infos,
         success: true,
-        message: "Worker reserved successfully".to_string(),
+        message,
     })
 }
 

--- a/crates/ci-controller/src/job_group_registry.rs
+++ b/crates/ci-controller/src/job_group_registry.rs
@@ -151,19 +151,60 @@ impl JobGroupRegistry {
             .find(|j| job_id_matches(&j.job_id, job_id))
     }
 
-    /// Check if all jobs in a group have reached terminal state.
-    /// Sets `status_reason` on the group when it transitions to a terminal state.
+    /// Check if a group has reached a terminal state.
+    ///
+    /// A group transitions to Success only when EVERY reserved stage has a
+    /// submitted job AND all submitted jobs are terminal. Reserved stages
+    /// that never get submitted keep the group in Running; the reservation
+    /// reaper (workers.stall_timeout_secs) will eventually Expire it.
+    ///
+    /// Failure / cancellation propagate as soon as any submitted job hits
+    /// that state — no need to wait for the rest in those cases.
+    ///
+    /// Sets `status_reason` on the group when it transitions to terminal.
     pub fn check_group_completion(&mut self, group_id: &Uuid) -> Option<JobGroupState> {
         let group = self.groups.get(group_id)?;
         if group.state.is_terminal() {
             return None;
         }
+        let reserved_stages: Vec<String> = group.reserved_stages.clone();
 
         let jobs = self.group_jobs.get(group_id)?;
         if jobs.is_empty() {
             return None;
         }
 
+        // Fast-fail: any failed/cancelled job collapses the whole group.
+        let any_failed = jobs.iter().any(|j| j.state == JobState::Failed);
+        let any_cancelled = jobs.iter().any(|j| j.state == JobState::Cancelled);
+
+        if any_failed || any_cancelled {
+            let (new_state, reason) = if any_failed {
+                let reason = jobs
+                    .iter()
+                    .find(|j| j.state == JobState::Failed)
+                    .map(|j| {
+                        let stage = j.stage_name.as_deref().unwrap_or("unknown");
+                        let code = j.exit_code.unwrap_or(-1);
+                        format!("Stage {stage} failed (exit code {code})")
+                    })
+                    .unwrap_or_else(|| "Stage failed".to_string());
+                (JobGroupState::Failed, reason)
+            } else {
+                (
+                    JobGroupState::Cancelled,
+                    "Cancelled: stage was cancelled".to_string(),
+                )
+            };
+            self.update_state(group_id, new_state);
+            if let Some(group) = self.groups.get_mut(group_id) {
+                group.status_reason = Some(reason);
+            }
+            return Some(new_state);
+        }
+
+        // Success path: ALL submitted jobs must be terminal AND every
+        // reserved stage must have a submitted job.
         let all_terminal = jobs.iter().all(|j| {
             matches!(
                 j.state,
@@ -174,38 +215,33 @@ impl JobGroupRegistry {
             return None;
         }
 
-        let any_failed = jobs.iter().any(|j| j.state == JobState::Failed);
-        let any_cancelled = jobs.iter().any(|j| j.state == JobState::Cancelled);
-
-        let (new_state, reason) = if any_failed {
-            // Find the first failed stage to include in the reason
-            let reason = jobs
+        if !reserved_stages.is_empty() {
+            // Every reserved stage name needs at least one submitted job.
+            // We don't enforce one-job-per-stage (retries can submit twice);
+            // having ≥1 job per reserved name is enough to call it "ran."
+            let submitted_stages: std::collections::HashSet<&str> = jobs
                 .iter()
-                .find(|j| j.state == JobState::Failed)
-                .map(|j| {
-                    let stage = j.stage_name.as_deref().unwrap_or("unknown");
-                    let code = j.exit_code.unwrap_or(-1);
-                    format!("Stage {stage} failed (exit code {code})")
-                })
-                .unwrap_or_else(|| "Stage failed".to_string());
-            (JobGroupState::Failed, reason)
-        } else if any_cancelled {
-            (
-                JobGroupState::Cancelled,
-                "Cancelled: stage was cancelled".to_string(),
-            )
-        } else {
-            (
-                JobGroupState::Success,
-                "All stages completed successfully".to_string(),
-            )
-        };
-
-        self.update_state(group_id, new_state);
-        if let Some(group) = self.groups.get_mut(group_id) {
-            group.status_reason = Some(reason);
+                .filter_map(|j| j.stage_name.as_deref())
+                .collect();
+            let missing: Vec<&str> = reserved_stages
+                .iter()
+                .map(|s| s.as_str())
+                .filter(|s| !submitted_stages.contains(s))
+                .collect();
+            if !missing.is_empty() {
+                // Submitted jobs are done; we're still waiting for the rest
+                // of the reservation manifest. Stay in Running — the
+                // stall_timeout reaper will Expire the group if no further
+                // submissions land.
+                return None;
+            }
         }
-        Some(new_state)
+
+        self.update_state(group_id, JobGroupState::Success);
+        if let Some(group) = self.groups.get_mut(group_id) {
+            group.status_reason = Some("All stages completed successfully".to_string());
+        }
+        Some(JobGroupState::Success)
     }
 
     /// Evict terminal groups older than `max_age`. Returns count evicted.

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -46,6 +46,7 @@ const JOB_GROUP_COLUMNS: &str =
     "id, repo_id, branch, commit_sha, trigger_source, reserved_worker_id, \
      state, priority, pr_number, idempotency_key, \
      allocated_cpu, allocated_memory_mb, allocated_disk_mb, \
+     reserved_stages, \
      status_reason, created_at, updated_at, completed_at";
 
 const JOB_COLUMNS: &str = "id, job_group_id, stage_config_id, stage_name, command, pre_script, \
@@ -176,6 +177,12 @@ fn map_job_group(r: sqlx::postgres::PgRow) -> JobGroup {
             memory_mb: r.try_get::<i64, _>("allocated_memory_mb").unwrap_or(0) as u64,
             disk_mb: r.try_get::<i64, _>("allocated_disk_mb").unwrap_or(0) as u64,
         },
+        // NULL on rows older than migration 034 → empty vec (legacy behavior).
+        reserved_stages: r
+            .try_get::<Option<Vec<String>>, _>("reserved_stages")
+            .ok()
+            .flatten()
+            .unwrap_or_default(),
         status_reason: r.try_get("status_reason").ok().flatten(),
         created_at: r.get("created_at"),
         updated_at,
@@ -1267,8 +1274,9 @@ impl Storage {
             "INSERT INTO job_groups (id, repo_id, branch, commit_sha, trigger_source, \
              reserved_worker_id, state, priority, pr_number, idempotency_key, \
              allocated_cpu, allocated_memory_mb, allocated_disk_mb, \
+             reserved_stages, \
              status_reason, created_at, updated_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) \
              RETURNING {JOB_GROUP_COLUMNS}"
         );
         let row = sqlx::query(&q)
@@ -1285,6 +1293,7 @@ impl Storage {
             .bind(group.allocated_resources.cpu as i32)
             .bind(group.allocated_resources.memory_mb as i64)
             .bind(group.allocated_resources.disk_mb as i64)
+            .bind(&group.reserved_stages)
             .bind(&group.status_reason)
             .bind(group.created_at)
             .bind(group.updated_at)

--- a/crates/ci-core/src/models/job_group.rs
+++ b/crates/ci-core/src/models/job_group.rs
@@ -77,6 +77,12 @@ pub struct JobGroup {
     /// Resources allocated on the worker for this group
     #[serde(default)]
     pub allocated_resources: AllocatedResources,
+    /// Stage names that were granted at reservation time (post silent-filter).
+    /// Empty for legacy rows or in-memory-only groups. When non-empty, group
+    /// completion requires that all of these have a submitted terminal job;
+    /// missing submissions trigger `stall_timeout_secs` expiry.
+    #[serde(default)]
+    pub reserved_stages: Vec<String>,
     pub status_reason: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -102,6 +108,7 @@ impl JobGroup {
             pr_number: None,
             idempotency_key: None,
             allocated_resources: AllocatedResources::default(),
+            reserved_stages: Vec::new(),
             status_reason: None,
             created_at: now,
             updated_at: now,
@@ -130,6 +137,7 @@ impl JobGroup {
             pr_number: None,
             idempotency_key: None,
             allocated_resources: AllocatedResources::default(),
+            reserved_stages: Vec::new(),
             status_reason: None,
             created_at: now,
             updated_at: now,

--- a/frontend/src/components/ui/StageTimeline.tsx
+++ b/frontend/src/components/ui/StageTimeline.tsx
@@ -71,16 +71,22 @@ export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
             aria-valuenow={durationBar(job.started_at, job.completed_at, maxMs)}
             aria-valuemin={0}
             aria-valuemax={100}
+            aria-busy={job.state === 'running'}
           >
-            <div
-              className={clsx(
-                'h-full rounded transition-all duration-500',
-                stateColor[job.state] ?? 'bg-surface-2',
-              )}
-              style={{ width: `${durationBar(job.started_at, job.completed_at, maxMs)}%` }}
-            />
-            {job.state === 'running' && (
-              <div className="absolute inset-0 bg-accent/20 animate-pulse rounded" aria-hidden="true" />
+            {job.state === 'running' ? (
+              // Running: full-width accent fill with marching diagonal
+              // stripes — the universal "in progress" signal. The
+              // numeric width-based duration animation isn't useful here
+              // because completed_at is null (job hasn't finished yet).
+              <div className="h-full w-full rounded bg-accent/60 animate-stripes" aria-hidden="true" />
+            ) : (
+              <div
+                className={clsx(
+                  'h-full rounded transition-all duration-500',
+                  stateColor[job.state] ?? 'bg-surface-2',
+                )}
+                style={{ width: `${durationBar(job.started_at, job.completed_at, maxMs)}%` }}
+              />
             )}
           </div>
 

--- a/frontend/src/components/ui/StageTimeline.tsx
+++ b/frontend/src/components/ui/StageTimeline.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { clsx } from 'clsx';
 import type { Job } from '../../types';
 import { StatusBadge } from './StatusBadge';
@@ -8,6 +9,20 @@ function durationBar(start: string | null, end: string | null, maxMs: number): n
   return Math.min((durationMs(start, end) / maxMs) * 100, 100);
 }
 
+/**
+ * Width % for a RUNNING stage's bar.
+ *  - With a per-stage timeout: grow elapsed/max toward 100% as the
+ *    deadline approaches (so the bar visibly fills up over time).
+ *  - Without a timeout: full width — there's no deadline to track, the
+ *    stripe animation alone signals "running".
+ */
+function runningBarPct(startedAt: string | null, maxDurationSecs: number, now: number): number {
+  if (!maxDurationSecs || maxDurationSecs <= 0) return 100;
+  if (!startedAt) return 100;
+  const elapsedSecs = Math.max(0, (now - new Date(startedAt).getTime()) / 1000);
+  return Math.min((elapsedSecs / maxDurationSecs) * 100, 100);
+}
+
 interface Props {
   jobs: Job[];
   onSelectJob: (job: Job) => void;
@@ -15,6 +30,16 @@ interface Props {
 }
 
 export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
+  // Tick every second while any stage is running so the growing-toward-
+  // timeout bars advance smoothly.
+  const hasRunning = jobs.some((j) => j.state === 'running');
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    if (!hasRunning) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [hasRunning]);
+
   const sorted = [...jobs].sort(
     (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
@@ -74,11 +99,15 @@ export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
             aria-busy={job.state === 'running'}
           >
             {job.state === 'running' ? (
-              // Running: full-width accent fill with marching diagonal
-              // stripes — the universal "in progress" signal. The
-              // numeric width-based duration animation isn't useful here
-              // because completed_at is null (job hasn't finished yet).
-              <div className="h-full w-full rounded bg-accent/60 animate-stripes" aria-hidden="true" />
+              // Running: marching diagonal stripes over an accent fill.
+              // With a per-stage timeout the bar grows elapsed/max toward
+              // 100% as the deadline nears; with no timeout it's full
+              // width and the stripes alone signal "in progress".
+              <div
+                className="h-full rounded bg-accent/60 animate-stripes transition-all duration-1000 ease-linear"
+                style={{ width: `${runningBarPct(job.started_at, job.max_duration_secs, now)}%` }}
+                aria-hidden="true"
+              />
             ) : (
               <div
                 className={clsx(

--- a/frontend/src/components/ui/StageTimeline.tsx
+++ b/frontend/src/components/ui/StageTimeline.tsx
@@ -2,25 +2,40 @@ import { useState, useEffect } from 'react';
 import { clsx } from 'clsx';
 import type { Job } from '../../types';
 import { StatusBadge } from './StatusBadge';
-import { formatDuration, durationMs } from '../../utils/duration';
-
-function durationBar(start: string | null, end: string | null, maxMs: number): number {
-  if (!start) return 0;
-  return Math.min((durationMs(start, end) / maxMs) * 100, 100);
-}
+import { formatDuration } from '../../utils/duration';
+import { formatSecs } from '../../utils/format';
 
 /**
- * Width % for a RUNNING stage's bar.
- *  - With a per-stage timeout: grow elapsed/max toward 100% as the
- *    deadline approaches (so the bar visibly fills up over time).
- *  - Without a timeout: full width — there's no deadline to track, the
- *    stripe animation alone signals "running".
+ * Bar fill fraction (0..1) for a stage, anchored to its OWN timeout budget
+ * — never to sibling stages. This is the key difference from the old
+ * relative-to-longest-sibling scaling, which made bars rescale (and appear
+ * to shrink) as other stages ran longer.
+ *
+ *  - With a timeout: elapsed / max_duration_secs, capped at 1.0. The bar
+ *    fills toward the deadline. A 20s stage on an 11m budget shows ~3%.
+ *  - Without a timeout: always full (1.0) — there's no budget to
+ *    proportion against.
+ *
+ * A small floor keeps a completed stage from rendering an invisible sliver.
  */
-function runningBarPct(startedAt: string | null, maxDurationSecs: number, now: number): number {
-  if (!maxDurationSecs || maxDurationSecs <= 0) return 100;
-  if (!startedAt) return 100;
-  const elapsedSecs = Math.max(0, (now - new Date(startedAt).getTime()) / 1000);
-  return Math.min((elapsedSecs / maxDurationSecs) * 100, 100);
+function barFraction(job: Job, now: number): number {
+  if (!job.started_at) return 0;
+  const elapsedMs = (job.completed_at ? new Date(job.completed_at).getTime() : now) - new Date(job.started_at).getTime();
+  const elapsedSecs = Math.max(0, elapsedMs / 1000);
+  const max = job.max_duration_secs;
+  if (!max || max <= 0) return 1; // no budget → full bar
+  const frac = Math.min(elapsedSecs / max, 1);
+  return Math.max(frac, 0.02); // floor so it's always visible once started
+}
+
+/** "20s / 11m (3%)" for budgeted stages, "20s" when there's no timeout. */
+function barLabel(job: Job, now: number): string {
+  const elapsed = formatDuration(job.started_at, job.completed_at);
+  const max = job.max_duration_secs;
+  if (!max || max <= 0) return elapsed;
+  const elapsedMs = (job.completed_at ? new Date(job.completed_at).getTime() : now) - new Date(job.started_at ?? now).getTime();
+  const pct = Math.round(Math.min((elapsedMs / 1000) / max, 1) * 100);
+  return `${elapsed} / ${formatSecs(max)} (${pct}%)`;
 }
 
 interface Props {
@@ -30,8 +45,8 @@ interface Props {
 }
 
 export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
-  // Tick every second while any stage is running so the growing-toward-
-  // timeout bars advance smoothly.
+  // Tick every second while any stage is running so the toward-timeout
+  // bars and countdown labels advance smoothly.
   const hasRunning = jobs.some((j) => j.state === 'running');
   const [now, setNow] = useState(Date.now());
   useEffect(() => {
@@ -43,13 +58,14 @@ export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
   const sorted = [...jobs].sort(
     (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
-  const maxMs = sorted.reduce((max, j) => Math.max(max, durationMs(j.started_at, j.completed_at)), 1000);
 
+  // Fill color by state. Running uses the striped accent fill (handled
+  // separately); terminal states get a solid status color.
   const stateColor: Record<string, string> = {
     success: 'bg-success',
     failed: 'bg-danger',
-    running: 'bg-accent',
     cancelled: 'bg-warning',
+    expired: 'bg-warning',
     queued: 'bg-surface-2',
     assigned: 'bg-accent/70',
     unknown: 'bg-warning',
@@ -57,79 +73,88 @@ export function StageTimeline({ jobs, onSelectJob, selectedJobId }: Props) {
 
   return (
     <div className="space-y-2" role="list" aria-label="Pipeline stages">
-      {sorted.map((job, i) => (
-        <div
-          key={job.id}
-          role="listitem"
-          onClick={() => onSelectJob(job)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectJob(job); } }}
-          tabIndex={0}
-          aria-label={`Stage ${i + 1}: ${job.stage_name}, ${job.state}`}
-          aria-pressed={selectedJobId === job.id}
-          className={clsx(
-            'flex items-center gap-4 px-4 py-3 rounded-lg cursor-pointer transition-all',
-            'focus:outline-none focus:ring-2 focus:ring-accent',
-            selectedJobId === job.id
-              ? 'bg-surface-2 ring-1 ring-accent/50'
-              : 'hover:bg-surface-hover/50',
-          )}
-        >
-          {/* Step number */}
-          <div
-            aria-hidden="true"
-            className="w-8 h-8 rounded-full bg-surface-2 flex items-center justify-center text-xs font-bold text-secondary shrink-0"
-          >
-            {i + 1}
-          </div>
+      {sorted.map((job, i) => {
+        const isRunning = job.state === 'running';
+        const frac = barFraction(job, now);
+        const label = barLabel(job, now);
+        const hasTimeout = !!job.max_duration_secs && job.max_duration_secs > 0;
+        // Remaining countdown for a running, budgeted stage.
+        const remainingSecs =
+          isRunning && hasTimeout && job.started_at
+            ? Math.max(0, job.max_duration_secs - Math.floor((now - new Date(job.started_at).getTime()) / 1000))
+            : null;
 
-          {/* Stage info */}
-          <div className="w-40 shrink-0">
-            <p className="text-sm font-medium text-secondary">{job.stage_name}</p>
-            <p className="text-xs text-disabled">{formatDuration(job.started_at, job.completed_at)}</p>
-          </div>
-
-          {/* Duration bar */}
+        return (
           <div
-            className="flex-1 h-6 bg-surface-2 rounded overflow-hidden relative"
-            role="progressbar"
-            aria-label={`Duration: ${formatDuration(job.started_at, job.completed_at)}`}
-            aria-valuenow={durationBar(job.started_at, job.completed_at, maxMs)}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-busy={job.state === 'running'}
+            key={job.id}
+            role="listitem"
+            onClick={() => onSelectJob(job)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectJob(job); } }}
+            tabIndex={0}
+            aria-label={`Stage ${i + 1}: ${job.stage_name}, ${job.state}`}
+            aria-pressed={selectedJobId === job.id}
+            className={clsx(
+              'flex items-center gap-4 px-4 py-3 rounded-lg cursor-pointer transition-all',
+              'focus:outline-none focus:ring-2 focus:ring-accent',
+              selectedJobId === job.id
+                ? 'bg-surface-2 ring-1 ring-accent/50'
+                : 'hover:bg-surface-hover/50',
+            )}
           >
-            {job.state === 'running' ? (
-              // Running: marching diagonal stripes over an accent fill.
-              // With a per-stage timeout the bar grows elapsed/max toward
-              // 100% as the deadline nears; with no timeout it's full
-              // width and the stripes alone signal "in progress".
-              <div
-                className="h-full rounded bg-accent/60 animate-stripes transition-all duration-1000 ease-linear"
-                style={{ width: `${runningBarPct(job.started_at, job.max_duration_secs, now)}%` }}
-                aria-hidden="true"
-              />
-            ) : (
+            {/* Step number */}
+            <div
+              aria-hidden="true"
+              className="w-8 h-8 rounded-full bg-surface-2 flex items-center justify-center text-xs font-bold text-secondary shrink-0"
+            >
+              {i + 1}
+            </div>
+
+            {/* Stage info: name + timeout-aware time line (per user request,
+                the timeout shows next to the stage name, not in the header). */}
+            <div className="w-48 shrink-0">
+              <p className="text-sm font-medium text-secondary truncate">{job.stage_name}</p>
+              <p className="text-xs text-disabled font-mono">
+                {isRunning && remainingSecs != null
+                  ? `${formatSecs(remainingSecs)} left / ${formatSecs(job.max_duration_secs)}`
+                  : isRunning && !hasTimeout
+                  ? `${formatDuration(job.started_at, null)} · no limit`
+                  : label}
+              </p>
+            </div>
+
+            {/* Duration / budget bar */}
+            <div
+              className="flex-1 h-6 bg-surface-2 rounded overflow-hidden relative"
+              role="progressbar"
+              aria-label={`Stage time: ${label}`}
+              aria-valuenow={Math.round(frac * 100)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-busy={isRunning}
+              title={label}
+            >
               <div
                 className={clsx(
-                  'h-full rounded transition-all duration-500',
-                  stateColor[job.state] ?? 'bg-surface-2',
+                  'h-full rounded transition-all ease-linear',
+                  isRunning ? 'bg-accent/60 animate-stripes duration-1000' : (stateColor[job.state] ?? 'bg-surface-2'),
+                  isRunning ? '' : 'duration-500',
                 )}
-                style={{ width: `${durationBar(job.started_at, job.completed_at, maxMs)}%` }}
+                style={{ width: `${frac * 100}%` }}
               />
-            )}
-          </div>
+            </div>
 
-          {/* Status */}
-          <div className="w-28 shrink-0 text-right">
-            <StatusBadge status={job.state} />
-          </div>
+            {/* Status */}
+            <div className="w-28 shrink-0 text-right">
+              <StatusBadge status={job.state} />
+            </div>
 
-          {/* Exit code */}
-          <div className="w-16 text-right text-xs text-disabled font-mono" aria-label={job.exit_code !== null ? `Exit code ${job.exit_code}` : ''}>
-            {job.exit_code !== null ? `exit ${job.exit_code}` : ''}
+            {/* Exit code */}
+            <div className="w-16 text-right text-xs text-disabled font-mono" aria-label={job.exit_code !== null ? `Exit code ${job.exit_code}` : ''}>
+              {job.exit_code !== null ? `exit ${job.exit_code}` : ''}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -76,7 +76,11 @@ const enumStyleMap: Record<string, string> = {
   disabled: 'bg-surface-2 text-muted border-border',
 };
 
-const pulseStatuses = new Set(['running', 'assigned', 'JOB_STATE_RUNNING', 'JOB_STATE_ASSIGNED', 'JOB_GROUP_STATE_RUNNING']);
+// `running` shows a spinning loader — far more visible than a pulse-dot
+// when scanning the page for the active stage. `assigned` (worker accepted
+// but not yet started) keeps the pulse-dot.
+const spinStatuses = new Set(['running', 'JOB_STATE_RUNNING', 'JOB_GROUP_STATE_RUNNING']);
+const pulseStatuses = new Set(['assigned', 'JOB_STATE_ASSIGNED']);
 
 /** Fallback: "JOB_STATE_RUNNING" -> "Running", "some_thing" -> "Some thing". */
 function prettify(raw: string): string {
@@ -106,6 +110,7 @@ export function StatusBadge({ status, size = 'sm', title }: Props) {
     'bg-surface-2/50 text-muted border-border';
 
   const pulse = pulseStatuses.has(status);
+  const spin = spinStatuses.has(status);
 
   return (
     <span
@@ -117,6 +122,17 @@ export function StatusBadge({ status, size = 'sm', title }: Props) {
       aria-label={`Status: ${label}`}
       title={title}
     >
+      {spin && (
+        <svg
+          className={clsx('animate-spin text-current', size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5')}
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="4" />
+          <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+        </svg>
+      )}
       {pulse && (
         <span className="relative flex h-2 w-2" aria-hidden="true">
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -249,3 +249,25 @@ button.bg-accent[disabled] {
 .bg-warning {
   background-image: var(--gradient-warning);
 }
+
+/* =============================================================================
+   PROGRESS-BAR ANIMATIONS — for stages that are actively running.
+   `marching-stripes` produces a barber-pole diagonal stripe sweep, the
+   universal "in progress" signal. Used by StageTimeline on running jobs.
+   ============================================================================= */
+@keyframes marching-stripes {
+  from { background-position: 0 0; }
+  to   { background-position: 40px 0; }
+}
+
+.animate-stripes {
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--color-accent) 0%,  transparent) 0px,
+    color-mix(in srgb, var(--color-accent) 0%,  transparent) 10px,
+    color-mix(in srgb, var(--color-accent) 35%, transparent) 10px,
+    color-mix(in srgb, var(--color-accent) 35%, transparent) 20px
+  );
+  background-size: 40px 40px;
+  animation: marching-stripes 1.2s linear infinite;
+}

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -333,12 +333,30 @@ function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: Ti
         : { status: 'deactivated', remaining_secs: null, max_secs: idleMax }
   );
 
+  const res = group.allocated_resources;
+  const hasRes = res && (res.cpu > 0 || res.memory_mb > 0 || res.disk_mb > 0);
+
   return (
     <div className="bg-surface border border-border rounded-xl p-4">
-      <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">
-        Timers{isTerminal && <span className="ml-2 normal-case text-disabled/70 font-normal">(final)</span>}
-      </h3>
-      <div className="space-y-3">
+      {/* Header row: card title on the left, compact reserved-resources
+          strip (clearly labelled) on the right. */}
+      <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+        <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider">
+          Timers &amp; Resources{isTerminal && <span className="ml-2 normal-case text-disabled/70 font-normal">— final</span>}
+        </h3>
+        {hasRes && (
+          <div className="flex items-center gap-3 text-xs font-mono text-secondary">
+            <span className="text-disabled uppercase tracking-wider not-italic font-sans text-[10px] font-semibold">Reserved</span>
+            <span title="Reserved CPU">{res!.cpu} <span className="text-disabled">CPU</span></span>
+            <span className="text-disabled/40">·</span>
+            <span title="Reserved memory">{formatBytes(res!.memory_mb)} <span className="text-disabled">RAM</span></span>
+            <span className="text-disabled/40">·</span>
+            <span title="Reserved disk">{formatBytes(res!.disk_mb)} <span className="text-disabled">Disk</span></span>
+          </div>
+        )}
+      </div>
+      {/* Two groups side-by-side on wider screens to keep the panel short. */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <TimerGroup title={`Stage timeouts${sortedJobs.length ? ` · ${sortedJobs.length}` : ''}`}>
           {sortedJobs.length > 0 ? (
             sortedJobs.map(j => <StageTimerRow key={j.id} job={j} />)
@@ -511,19 +529,7 @@ export default function BuildDetailPage() {
         </div>
       </div>
 
-      {/* Reserved resources */}
-      {group.allocated_resources && (group.allocated_resources.cpu > 0 || group.allocated_resources.memory_mb > 0 || group.allocated_resources.disk_mb > 0) && (
-        <div className="bg-surface-2/50 border border-border rounded-lg px-4 py-3">
-          <p className="text-xs text-disabled mb-1.5 uppercase font-semibold">Resources Reserved</p>
-          <div className="flex gap-6 text-sm">
-            <span className="text-secondary">{group.allocated_resources.cpu} <span className="text-disabled">CPU cores</span></span>
-            <span className="text-secondary">{formatBytes(group.allocated_resources.memory_mb)} <span className="text-disabled">RAM</span></span>
-            <span className="text-secondary">{formatBytes(group.allocated_resources.disk_mb)} <span className="text-disabled">Disk</span></span>
-          </div>
-        </div>
-      )}
-
-      {/* Timers panel */}
+      {/* Timers + reserved resources (combined to save vertical space) */}
       <TimersPanel group={group} jobs={jobs} />
 
       {/* Reserved stages manifest — shows every stage that was granted at

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -445,6 +445,35 @@ export default function BuildDetailPage() {
       {/* Timers panel */}
       <TimersPanel group={group} jobs={jobs} />
 
+      {/* Reserved stages manifest — shows every stage that was granted at
+          reservation time and its current state (Pending until submitted). */}
+      {group.reserved_stages && group.reserved_stages.length > 0 && (
+        <div className="bg-surface border border-border rounded-xl">
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-secondary">
+              Reserved stages ({jobs.length} / {group.reserved_stages.length} submitted)
+            </h3>
+            {jobs.length < group.reserved_stages.length && !isTerminal && (
+              <span className="text-xs text-muted">Waiting for {group.reserved_stages.length - jobs.length} more</span>
+            )}
+          </div>
+          <div className="px-4 py-3 flex flex-wrap gap-2">
+            {group.reserved_stages.map((stageName) => {
+              const job = jobs.find((j) => j.stage_name === stageName);
+              return (
+                <div
+                  key={stageName}
+                  className="inline-flex items-center gap-2 bg-surface-2/50 border border-border rounded-lg pl-3 pr-2 py-1.5"
+                >
+                  <span className="text-sm text-secondary font-mono">{stageName}</span>
+                  <StatusBadge status={job ? job.state : 'pending'} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Stage pipeline timeline */}
       <div className="bg-surface border border-border rounded-xl">
         <div className="px-4 py-3 border-b border-border">

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getBuild, cancelBuild, retryBuild, retryJob } from '../api/builds';
@@ -230,14 +231,34 @@ function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: Ti
   const isTerminal = ['success', 'failed', 'cancelled', 'expired'].includes(group.state);
   if (isTerminal) return null;
 
-  const runningJob = jobs.find(j => j.state === 'running') ?? null;
+  // ALL currently-running jobs, not just the first one. Parallel stages
+  // each get their own stage-timeout row.
+  const runningJobs = jobs.filter(j => j.state === 'running');
 
   if (group.timers) {
+    // Server-side computed timers — render one stage row per running job
+    // (server only ships a single `timers.stage`, so fall back to it for
+    // the first running job and compute the rest client-side from
+    // max_duration_secs on each running Job).
     return (
       <div className="bg-surface border border-border rounded-xl p-4">
         <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">Timers</h3>
         <div className="space-y-2">
-          <TimerRow label="Stage timeout" timer={group.timers.stage} job={runningJob} />
+          {runningJobs.length === 0 && (
+            <TimerRow label="Stage timeout" timer={group.timers.stage} job={null} />
+          )}
+          {runningJobs.map((j, idx) => (
+            <TimerRow
+              key={j.id}
+              label={`Stage timeout: ${j.stage_name}`}
+              timer={
+                idx === 0 && group.timers?.stage
+                  ? group.timers.stage
+                  : buildStageTimerFromJob(j)
+              }
+              job={j}
+            />
+          ))}
           <TimerRow label="Stall timeout" timer={group.timers.stall} />
           <TimerRow label="Idle timeout" timer={group.timers.idle} />
         </div>
@@ -245,13 +266,10 @@ function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: Ti
     );
   }
 
-  const hasRunning = jobs.some(j => j.state === 'running' || j.state === 'assigned');
+  // Client-side computed fallback when the server doesn't ship `timers`.
+  const hasRunning = runningJobs.length > 0 || jobs.some(j => j.state === 'assigned');
   const idleMax = group.idle_timeout_secs ?? 300;
   const stallMax = group.stall_timeout_secs ?? 1800;
-
-  const stageTimer: TimerInfo = runningJob && runningJob.max_duration_secs > 0 && runningJob.started_at
-    ? { status: 'active', remaining_secs: runningJob.max_duration_secs - Math.floor((Date.now() - new Date(runningJob.started_at).getTime()) / 1000), max_secs: runningJob.max_duration_secs, reason: `Active (${runningJob.stage_name})` }
-    : { status: 'na', remaining_secs: null, max_secs: runningJob?.max_duration_secs ?? 0 };
 
   const stallTimer: TimerInfo = group.state === 'running'
     ? hasRunning
@@ -267,12 +285,91 @@ function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: Ti
     <div className="bg-surface border border-border rounded-xl p-4">
       <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">Timers</h3>
       <div className="space-y-2">
-        <TimerRow label="Stage timeout" timer={stageTimer} />
+        {runningJobs.length === 0 ? (
+          <TimerRow
+            label="Stage timeout"
+            timer={{ status: 'na', remaining_secs: null, max_secs: 0 }}
+          />
+        ) : (
+          runningJobs.map(j => (
+            <TimerRow
+              key={j.id}
+              label={`Stage timeout: ${j.stage_name}`}
+              timer={buildStageTimerFromJob(j)}
+              job={j}
+            />
+          ))
+        )}
         <TimerRow label="Stall timeout" timer={stallTimer} />
         <TimerRow label="Idle timeout" timer={idleTimer} />
       </div>
     </div>
   );
+}
+
+/**
+ * Compact "<stage>: 02:35 / 30m" chip for the Pipeline header — one per
+ * currently-running stage. Color shifts to warning/danger as the
+ * countdown closes in on the per-stage max_duration_secs.
+ */
+function RunningStageChip({ job }: { job: Job }) {
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!job.started_at) return null;
+  const elapsed = Math.max(0, Math.floor((now - new Date(job.started_at).getTime()) / 1000));
+  const maxSecs = job.max_duration_secs || 0;
+
+  let timeLabel: string;
+  let colorClass: string;
+  if (maxSecs > 0) {
+    const remaining = Math.max(0, maxSecs - elapsed);
+    const pct = elapsed / maxSecs;
+    colorClass =
+      pct > 0.9
+        ? 'bg-danger-soft text-danger border-danger/30'
+        : pct > 0.7
+        ? 'bg-warning-soft text-warning border-warning/30'
+        : 'bg-accent-soft text-accent-text border-accent/30';
+    timeLabel = `${formatSecs(remaining)} / ${formatSecs(maxSecs)}`;
+  } else {
+    colorClass = 'bg-accent-soft text-accent-text border-accent/30';
+    timeLabel = formatSecs(elapsed);
+  }
+
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-2 border rounded-full px-2.5 py-0.5 text-xs font-mono',
+        colorClass,
+      )}
+      title={`${job.stage_name}: ${timeLabel}`}
+    >
+      <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="4" />
+        <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+      </svg>
+      <span className="font-semibold">{job.stage_name}</span>
+      <span>{timeLabel}</span>
+    </span>
+  );
+}
+
+/** Build a client-side TimerInfo from a running job's max_duration_secs. */
+function buildStageTimerFromJob(job: Job): TimerInfo {
+  if (!job.started_at || !job.max_duration_secs || job.max_duration_secs <= 0) {
+    return { status: 'na', remaining_secs: null, max_secs: job.max_duration_secs ?? 0 };
+  }
+  const elapsed = Math.floor((Date.now() - new Date(job.started_at).getTime()) / 1000);
+  return {
+    status: 'active',
+    remaining_secs: Math.max(0, job.max_duration_secs - elapsed),
+    max_secs: job.max_duration_secs,
+    reason: `Active (${job.stage_name})`,
+  };
 }
 
 // ── Main page ─────────────────────────────────────────────────────────────────
@@ -476,10 +573,20 @@ export default function BuildDetailPage() {
 
       {/* Stage pipeline timeline */}
       <div className="bg-surface border border-border rounded-xl">
-        <div className="px-4 py-3 border-b border-border">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3 flex-wrap">
           <h3 className="text-sm font-semibold text-secondary">
             Pipeline ({jobs.length} stage{jobs.length !== 1 ? 's' : ''})
           </h3>
+          {/* Show per-running-stage countdown chips so users see at a
+              glance how long each active stage has before its
+              max_duration_secs hits. */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {jobs
+              .filter((j) => j.state === 'running')
+              .map((j) => (
+                <RunningStageChip key={j.id} job={j} />
+              ))}
+          </div>
         </div>
         {jobs.length > 0 ? (
           <div className="p-2">

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { clsx } from 'clsx';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -227,149 +227,133 @@ function TimerRow({ label, timer, job }: { label: string; timer: TimerInfo | und
   );
 }
 
-function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: TimerInfo; stall?: TimerInfo; stage?: TimerInfo } }; jobs: Job[] }) {
-  const isTerminal = ['success', 'failed', 'cancelled', 'expired'].includes(group.state);
-  if (isTerminal) return null;
-
-  // ALL currently-running jobs, not just the first one. Parallel stages
-  // each get their own stage-timeout row.
-  const runningJobs = jobs.filter(j => j.state === 'running');
-
-  if (group.timers) {
-    // Server-side computed timers — render one stage row per running job
-    // (server only ships a single `timers.stage`, so fall back to it for
-    // the first running job and compute the rest client-side from
-    // max_duration_secs on each running Job).
-    return (
-      <div className="bg-surface border border-border rounded-xl p-4">
-        <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">Timers</h3>
-        <div className="space-y-2">
-          {runningJobs.length === 0 && (
-            <TimerRow label="Stage timeout" timer={group.timers.stage} job={null} />
-          )}
-          {runningJobs.map((j, idx) => (
-            <TimerRow
-              key={j.id}
-              label={`Stage timeout: ${j.stage_name}`}
-              timer={
-                idx === 0 && group.timers?.stage
-                  ? group.timers.stage
-                  : buildStageTimerFromJob(j)
-              }
-              job={j}
-            />
-          ))}
-          <TimerRow label="Stall timeout" timer={group.timers.stall} />
-          <TimerRow label="Idle timeout" timer={group.timers.idle} />
-        </div>
-      </div>
-    );
-  }
-
-  // Client-side computed fallback when the server doesn't ship `timers`.
-  const hasRunning = runningJobs.length > 0 || jobs.some(j => j.state === 'assigned');
-  const idleMax = group.idle_timeout_secs ?? 300;
-  const stallMax = group.stall_timeout_secs ?? 1800;
-
-  const stallTimer: TimerInfo = group.state === 'running'
-    ? hasRunning
-      ? { status: 'paused', remaining_secs: null, max_secs: stallMax, reason: 'Paused (stage running)' }
-      : { status: 'active', remaining_secs: group.time_until_timeout_secs ?? stallMax, max_secs: stallMax, reason: 'Waiting for next stage' }
-    : { status: 'na', remaining_secs: null, max_secs: stallMax };
-
-  const idleTimer: TimerInfo = group.state === 'reserved'
-    ? { status: 'active', remaining_secs: group.time_until_timeout_secs ?? idleMax, max_secs: idleMax, reason: 'Waiting for first stage' }
-    : { status: 'deactivated', remaining_secs: null, max_secs: idleMax };
-
+/** Subheading + bordered group inside the Timers panel. */
+function TimerGroup({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div className="bg-surface border border-border rounded-xl p-4">
-      <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">Timers</h3>
-      <div className="space-y-2">
-        {runningJobs.length === 0 ? (
-          <TimerRow
-            label="Stage timeout"
-            timer={{ status: 'na', remaining_secs: null, max_secs: 0 }}
-          />
-        ) : (
-          runningJobs.map(j => (
-            <TimerRow
-              key={j.id}
-              label={`Stage timeout: ${j.stage_name}`}
-              timer={buildStageTimerFromJob(j)}
-              job={j}
-            />
-          ))
-        )}
-        <TimerRow label="Stall timeout" timer={stallTimer} />
-        <TimerRow label="Idle timeout" timer={idleTimer} />
-      </div>
+    <div className="rounded-lg border border-border/60 bg-surface-2/30 p-3">
+      <p className="text-[11px] font-semibold text-disabled uppercase tracking-wider mb-2">{title}</p>
+      <div className="space-y-2">{children}</div>
     </div>
   );
 }
 
 /**
- * Compact "<stage>: 02:35 / 30m" chip for the Pipeline header — one per
- * currently-running stage. Color shifts to warning/danger as the
- * countdown closes in on the per-stage max_duration_secs.
+ * One row per stage in the Timers panel. Works for running AND terminal
+ * stages:
+ *  - running + timeout: live "X left / max" countdown, color escalates as
+ *    the deadline nears.
+ *  - running, no timeout: elapsed + "no limit".
+ *  - terminal: final "used Y / max (pct)" — so people can see, after the
+ *    fact, how much of each stage's budget was consumed.
  */
-function RunningStageChip({ job }: { job: Job }) {
+function StageTimerRow({ job }: { job: Job }) {
+  const isRunning = job.state === 'running';
   const [now, setNow] = useState(Date.now());
   useEffect(() => {
+    if (!isRunning) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [isRunning]);
 
-  if (!job.started_at) return null;
-  const elapsed = Math.max(0, Math.floor((now - new Date(job.started_at).getTime()) / 1000));
   const maxSecs = job.max_duration_secs || 0;
+  const endMs = job.completed_at ? new Date(job.completed_at).getTime() : now;
+  const elapsedSecs = job.started_at
+    ? Math.max(0, Math.floor((endMs - new Date(job.started_at).getTime()) / 1000))
+    : 0;
+  const pct = maxSecs > 0 ? elapsedSecs / maxSecs : 0;
 
-  let timeLabel: string;
-  let colorClass: string;
-  if (maxSecs > 0) {
-    const remaining = Math.max(0, maxSecs - elapsed);
-    const pct = elapsed / maxSecs;
-    colorClass =
-      pct > 0.9
-        ? 'bg-danger-soft text-danger border-danger/30'
-        : pct > 0.7
-        ? 'bg-warning-soft text-warning border-warning/30'
-        : 'bg-accent-soft text-accent-text border-accent/30';
-    timeLabel = `${formatSecs(remaining)} / ${formatSecs(maxSecs)}`;
+  // Icon + color by lifecycle.
+  let icon: string;
+  let color: string;
+  if (isRunning) {
+    icon = '⏱';
+    color = pct > 0.9 ? 'text-danger' : pct > 0.7 ? 'text-warning' : 'text-success';
+  } else if (job.state === 'success') {
+    icon = '✓';
+    color = 'text-disabled';
+  } else if (job.state === 'failed') {
+    icon = '✗';
+    color = 'text-danger';
   } else {
-    colorClass = 'bg-accent-soft text-accent-text border-accent/30';
-    timeLabel = formatSecs(elapsed);
+    icon = '○';
+    color = 'text-disabled';
+  }
+
+  const maxLabel = maxSecs > 0 ? formatSecs(maxSecs) : 'no limit';
+  let timeDisplay: string;
+  if (isRunning && maxSecs > 0) {
+    timeDisplay = `${formatSecs(Math.max(0, maxSecs - elapsedSecs))} left / ${maxLabel}`;
+  } else if (maxSecs > 0) {
+    timeDisplay = `${formatSecs(elapsedSecs)} / ${maxLabel} (${Math.round(Math.min(pct, 1) * 100)}%)`;
+  } else {
+    timeDisplay = `${formatSecs(elapsedSecs)} / ${maxLabel}`;
   }
 
   return (
-    <span
-      className={clsx(
-        'inline-flex items-center gap-2 border rounded-full px-2.5 py-0.5 text-xs font-mono',
-        colorClass,
-      )}
-      title={`${job.stage_name}: ${timeLabel}`}
-    >
-      <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="4" />
-        <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
-      </svg>
-      <span className="font-semibold">{job.stage_name}</span>
-      <span>{timeLabel}</span>
-    </span>
+    <div className="flex items-center justify-between text-xs">
+      <div className="flex items-center gap-2 min-w-0">
+        <span aria-hidden="true">{icon}</span>
+        <span className="text-secondary font-mono truncate">{job.stage_name}</span>
+      </div>
+      <span className={`${color} font-mono shrink-0`}>{timeDisplay}</span>
+    </div>
   );
 }
 
-/** Build a client-side TimerInfo from a running job's max_duration_secs. */
-function buildStageTimerFromJob(job: Job): TimerInfo {
-  if (!job.started_at || !job.max_duration_secs || job.max_duration_secs <= 0) {
-    return { status: 'na', remaining_secs: null, max_secs: job.max_duration_secs ?? 0 };
-  }
-  const elapsed = Math.floor((Date.now() - new Date(job.started_at).getTime()) / 1000);
-  return {
-    status: 'active',
-    remaining_secs: Math.max(0, job.max_duration_secs - elapsed),
-    max_secs: job.max_duration_secs,
-    reason: `Active (${job.stage_name})`,
-  };
+function TimersPanel({ group, jobs }: { group: JobGroup & { timers?: { idle?: TimerInfo; stall?: TimerInfo; stage?: TimerInfo } }; jobs: Job[] }) {
+  const isTerminal = ['success', 'failed', 'cancelled', 'expired'].includes(group.state);
+
+  // Show every stage that has a job (running or finished) so the panel is
+  // useful both live and as a post-mortem.
+  const sortedJobs = [...jobs].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+  const hasRunning = jobs.some(j => j.state === 'running' || j.state === 'assigned');
+
+  // ── Build-level timers (stall + idle). Prefer server-computed values;
+  // otherwise compute a sensible client-side view. ──
+  const idleMax = group.timers?.idle?.max_secs ?? group.idle_timeout_secs ?? 300;
+  const stallMax = group.timers?.stall?.max_secs ?? group.stall_timeout_secs ?? 1800;
+
+  const stallTimer: TimerInfo = group.timers?.stall ?? (
+    isTerminal
+      ? { status: 'deactivated', remaining_secs: null, max_secs: stallMax, reason: 'Build finished' }
+      : group.state === 'running'
+        ? hasRunning
+          ? { status: 'paused', remaining_secs: null, max_secs: stallMax, reason: 'Paused (stage running)' }
+          : { status: 'active', remaining_secs: group.time_until_timeout_secs ?? stallMax, max_secs: stallMax, reason: 'Waiting for next stage' }
+        : { status: 'na', remaining_secs: null, max_secs: stallMax }
+  );
+
+  const idleTimer: TimerInfo = group.timers?.idle ?? (
+    isTerminal
+      ? { status: 'deactivated', remaining_secs: null, max_secs: idleMax, reason: 'Build finished' }
+      : group.state === 'reserved'
+        ? { status: 'active', remaining_secs: group.time_until_timeout_secs ?? idleMax, max_secs: idleMax, reason: 'Waiting for first stage' }
+        : { status: 'deactivated', remaining_secs: null, max_secs: idleMax }
+  );
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-4">
+      <h3 className="text-xs font-semibold text-disabled uppercase tracking-wider mb-3">
+        Timers{isTerminal && <span className="ml-2 normal-case text-disabled/70 font-normal">(final)</span>}
+      </h3>
+      <div className="space-y-3">
+        <TimerGroup title={`Stage timeouts${sortedJobs.length ? ` · ${sortedJobs.length}` : ''}`}>
+          {sortedJobs.length > 0 ? (
+            sortedJobs.map(j => <StageTimerRow key={j.id} job={j} />)
+          ) : (
+            <p className="text-xs text-disabled italic">No stages submitted yet</p>
+          )}
+        </TimerGroup>
+
+        <TimerGroup title="Build timeouts">
+          <TimerRow label="Stall timeout" timer={stallTimer} />
+          <TimerRow label="Idle timeout" timer={idleTimer} />
+        </TimerGroup>
+      </div>
+    </div>
+  );
 }
 
 // ── Main page ─────────────────────────────────────────────────────────────────
@@ -571,22 +555,13 @@ export default function BuildDetailPage() {
         </div>
       )}
 
-      {/* Stage pipeline timeline */}
+      {/* Stage pipeline timeline. Per-stage timeout/countdown is rendered
+          inside each row (next to the stage name) by StageTimeline. */}
       <div className="bg-surface border border-border rounded-xl">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3 flex-wrap">
+        <div className="px-4 py-3 border-b border-border">
           <h3 className="text-sm font-semibold text-secondary">
             Pipeline ({jobs.length} stage{jobs.length !== 1 ? 's' : ''})
           </h3>
-          {/* Show per-running-stage countdown chips so users see at a
-              glance how long each active stage has before its
-              max_duration_secs hits. */}
-          <div className="flex items-center gap-2 flex-wrap">
-            {jobs
-              .filter((j) => j.state === 'running')
-              .map((j) => (
-                <RunningStageChip key={j.id} job={j} />
-              ))}
-          </div>
         </div>
         {jobs.length > 0 ? (
           <div className="p-2">

--- a/frontend/src/pages/BuildsPage.tsx
+++ b/frontend/src/pages/BuildsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { listBuilds } from '../api/builds';
 import { useAppliedFilters } from '../hooks/useAppliedFilters';
 import { useRefreshInterval } from '../hooks/useRefreshInterval';
@@ -11,6 +11,7 @@ import { TimeAgo } from '../components/ui/TimeAgo';
 import { TableSkeleton } from '../components/ui/PageSkeleton';
 
 export default function BuildsPage() {
+  const navigate = useNavigate();
   const { applied, draft, patchDraft, apply, applyPatch, reset, isDirty } = useAppliedFilters();
   const [refreshSecs, setRefreshSecs] = useRefreshInterval('builds', 5);
   const [queryValue, setQueryValue] = useState(applied.q);
@@ -97,24 +98,38 @@ export default function BuildsPage() {
                   {builds.map(b => {
                     const href = `/builds/${b.job_group_id}`;
                     return (
-                      <tr key={b.job_group_id} className={`relative hover:bg-surface-hover/50 transition-colors${b.archived ? ' opacity-60' : ''}`}>
+                      <tr
+                        key={b.job_group_id}
+                        onClick={() => navigate(href)}
+                        className={`cursor-pointer hover:bg-surface-hover/50 transition-colors${b.archived ? ' opacity-60' : ''}`}
+                      >
                         <td className="px-4 py-3">
-                          <Link to={href} aria-label={`Build ${b.job_group_id.slice(0, 8)}${b.branch ? ` on ${b.branch}` : ''} — ${b.state}${b.archived ? ' (archived)' : ''}`} className="absolute inset-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent" />
-                          <span className="relative z-10">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <StatusBadge status={b.state} />
-                              {b.archived && <StatusBadge status="archived" />}
-                            </div>
-                            {b.status_reason && (
-                              <span className="block text-[10px] text-disabled truncate max-w-[180px]">{b.status_reason}</span>
-                            )}
-                          </span>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <StatusBadge status={b.state} />
+                            {b.archived && <StatusBadge status="archived" />}
+                          </div>
+                          {b.status_reason && (
+                            <span className="block text-[10px] text-disabled truncate max-w-[180px]">{b.status_reason}</span>
+                          )}
                         </td>
-                        <td className="px-4 py-3 text-sm text-secondary font-mono relative z-10">{b.job_group_id.slice(0, 8)}</td>
-                        <td className="px-4 py-3 text-sm text-secondary relative z-10">{b.branch || '-'}</td>
-                        <td className="px-4 py-3 text-sm text-muted font-mono relative z-10">{b.commit_sha?.slice(0, 7) || '-'}</td>
-                        <td className="px-4 py-3 text-sm text-muted relative z-10">{b.reserved_worker_id ?? '-'}</td>
-                        <td className="px-4 py-3 text-sm relative z-10">
+                        <td className="px-4 py-3 text-sm text-secondary font-mono">
+                          {/* Real anchor on the ID so cmd/middle-click opens a
+                              new tab and keyboard users get a focusable target.
+                              stopPropagation avoids a double-navigate with the
+                              row onClick. */}
+                          <Link
+                            to={href}
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label={`Build ${b.job_group_id.slice(0, 8)}${b.branch ? ` on ${b.branch}` : ''} — ${b.state}${b.archived ? ' (archived)' : ''}`}
+                            className="hover:text-accent-text focus:outline-none focus:ring-2 focus:ring-accent rounded"
+                          >
+                            {b.job_group_id.slice(0, 8)}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-secondary">{b.branch || '-'}</td>
+                        <td className="px-4 py-3 text-sm text-muted font-mono">{b.commit_sha?.slice(0, 7) || '-'}</td>
+                        <td className="px-4 py-3 text-sm text-muted">{b.reserved_worker_id ?? '-'}</td>
+                        <td className="px-4 py-3 text-sm">
                           <TimeAgo date={b.created_at} className="text-disabled" />
                         </td>
                       </tr>

--- a/frontend/src/types/build.ts
+++ b/frontend/src/types/build.ts
@@ -24,6 +24,10 @@ export interface JobGroup {
   trigger_source: string;
   reserved_worker_id: string | null;
   state: JobGroupState;
+  /** Granted stage manifest at reservation time (post silent-filter). */
+  reserved_stages?: string[];
+  /** Stage names that have a submitted job. Derived from `jobs[].stage_name`. */
+  submitted_stages?: string[];
   allocated_resources?: AllocatedResources;
   last_activity_at?: string | null;
   time_until_timeout_secs?: number | null;

--- a/migrations/034_reserved_stages.sql
+++ b/migrations/034_reserved_stages.sql
@@ -1,0 +1,224 @@
+-- 034_reserved_stages.sql
+--
+-- Track the granted (effective) stage list at reservation time so the
+-- controller can wait for ALL reserved stages to complete before marking
+-- a job group terminal. Today `check_group_completion` only inspects
+-- submitted jobs, so a group of [a, b] gets marked Success the instant
+-- stage `a` finishes — even if `b` is reserved but never submitted.
+--
+-- The new column stores the post-silent-filter stage list (i.e. only
+-- stages that are actually configured for the repo). Pre-existing rows
+-- get NULL → handled as "old shape, keep current behavior" by the
+-- runtime; we don't backfill.
+--
+-- Mirror the column on the archive table so retention sweeps stay schema-
+-- compatible with the live table.
+
+BEGIN;
+
+ALTER TABLE chola.job_groups
+    ADD COLUMN IF NOT EXISTS reserved_stages TEXT[];
+
+ALTER TABLE chola.job_groups_archive
+    ADD COLUMN IF NOT EXISTS reserved_stages TEXT[];
+
+COMMENT ON COLUMN chola.job_groups.reserved_stages IS
+    'Granted stage names at reservation time (post silent-filter). When NULL or empty, group completion falls back to legacy "first-finished-stage wins" semantics.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Update the archive / unarchive stored functions (migration 033) so
+-- reserved_stages survives the live ↔ archive round-trip.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION chola.archive_group_ids(group_ids UUID[])
+RETURNS BIGINT
+LANGUAGE plpgsql
+VOLATILE
+AS $fn$
+DECLARE
+    affected BIGINT;
+BEGIN
+    -- INSERT children first, parent last (FK to job_groups still live).
+    INSERT INTO chola.approval_gates_archive (
+        id, job_group_id, stage_config_id, status, required_role,
+        requested_at, responded_at, responded_by, timeout_minutes, comment,
+        archived_at
+    )
+    SELECT
+        id, job_group_id, stage_config_id, status, required_role,
+        requested_at, responded_at, responded_by, timeout_minutes, comment,
+        NOW()
+    FROM chola.approval_gates
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.test_results_archive (
+        id, job_id, job_group_id, suite_name, test_name, classname, status,
+        duration_ms, failure_message, failure_type, stdout, stderr,
+        created_at, archived_at
+    )
+    SELECT
+        id, job_id, job_group_id, suite_name, test_name, classname, status,
+        duration_ms, failure_message, failure_type, stdout, stderr,
+        created_at, NOW()
+    FROM chola.test_results
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.artifacts_archive (
+        id, job_group_id, job_id, stage_name, filename, file_path,
+        size_bytes, content_type, created_at, archived_at
+    )
+    SELECT
+        id, job_group_id, job_id, stage_name, filename, file_path,
+        size_bytes, content_type, created_at, NOW()
+    FROM chola.artifacts
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.worker_reservations_archive (
+        id, worker_id, job_group_id, reserved_at, expires_at, released_at,
+        release_reason, archived_at
+    )
+    SELECT
+        id, worker_id, job_group_id, reserved_at, expires_at, released_at,
+        release_reason, NOW()
+    FROM chola.worker_reservations
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.jobs_archive (
+        id, job_group_id, stage_config_id, stage_name, command, pre_script,
+        post_script, worker_id, state, exit_code, pre_exit_code,
+        post_exit_code, log_path, started_at, completed_at, created_at,
+        updated_at, retry_count, status_reason, archived_at
+    )
+    SELECT
+        id, job_group_id, stage_config_id, stage_name, command, pre_script,
+        post_script, worker_id, state, exit_code, pre_exit_code,
+        post_exit_code, log_path, started_at, completed_at, created_at,
+        updated_at, retry_count, status_reason, NOW()
+    FROM chola.jobs
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.job_groups_archive (
+        id, repo_id, branch, commit_sha, trigger_source, reserved_worker_id,
+        state, created_at, updated_at, completed_at, priority, pr_number,
+        pinned, idempotency_key, allocated_cpu, allocated_memory_mb,
+        allocated_disk_mb, reserved_stages, status_reason, archived_at,
+        files_purged_at
+    )
+    SELECT
+        id, repo_id, branch, commit_sha, trigger_source, reserved_worker_id,
+        state, created_at, updated_at, completed_at, priority, pr_number,
+        pinned, idempotency_key, allocated_cpu, allocated_memory_mb,
+        allocated_disk_mb, reserved_stages, status_reason, NOW(),
+        files_purged_at
+    FROM chola.job_groups
+    WHERE id = ANY(group_ids);
+
+    GET DIAGNOSTICS affected = ROW_COUNT;
+
+    -- DELETE children first, parent last (FK from live children still
+    -- references live parent until the parent row goes away).
+    DELETE FROM chola.approval_gates      WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.test_results        WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.artifacts           WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.worker_reservations WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.jobs                WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.job_groups          WHERE id            = ANY(group_ids);
+
+    RETURN affected;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION chola.unarchive_group_ids(group_ids UUID[])
+RETURNS BIGINT
+LANGUAGE plpgsql
+VOLATILE
+AS $fn$
+DECLARE
+    affected BIGINT;
+BEGIN
+    -- Parent first into live so children's FK to job_groups is satisfied.
+    INSERT INTO chola.job_groups (
+        id, repo_id, branch, commit_sha, trigger_source, reserved_worker_id,
+        state, created_at, updated_at, completed_at, priority, pr_number,
+        pinned, idempotency_key, allocated_cpu, allocated_memory_mb,
+        allocated_disk_mb, reserved_stages, status_reason, files_purged_at
+    )
+    SELECT
+        id, repo_id, branch, commit_sha, trigger_source, reserved_worker_id,
+        state, created_at, updated_at, completed_at, priority, pr_number,
+        pinned, idempotency_key, allocated_cpu, allocated_memory_mb,
+        allocated_disk_mb, reserved_stages, status_reason, files_purged_at
+    FROM chola.job_groups_archive
+    WHERE id = ANY(group_ids);
+
+    GET DIAGNOSTICS affected = ROW_COUNT;
+
+    INSERT INTO chola.jobs (
+        id, job_group_id, stage_config_id, stage_name, command, pre_script,
+        post_script, worker_id, state, exit_code, pre_exit_code,
+        post_exit_code, log_path, started_at, completed_at, created_at,
+        updated_at, retry_count, status_reason
+    )
+    SELECT
+        id, job_group_id, stage_config_id, stage_name, command, pre_script,
+        post_script, worker_id, state, exit_code, pre_exit_code,
+        post_exit_code, log_path, started_at, completed_at, created_at,
+        updated_at, retry_count, status_reason
+    FROM chola.jobs_archive
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.worker_reservations (
+        id, worker_id, job_group_id, reserved_at, expires_at, released_at,
+        release_reason
+    )
+    SELECT
+        id, worker_id, job_group_id, reserved_at, expires_at, released_at,
+        release_reason
+    FROM chola.worker_reservations_archive
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.artifacts (
+        id, job_group_id, job_id, stage_name, filename, file_path,
+        size_bytes, content_type, created_at
+    )
+    SELECT
+        id, job_group_id, job_id, stage_name, filename, file_path,
+        size_bytes, content_type, created_at
+    FROM chola.artifacts_archive
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.test_results (
+        id, job_id, job_group_id, suite_name, test_name, classname, status,
+        duration_ms, failure_message, failure_type, stdout, stderr,
+        created_at
+    )
+    SELECT
+        id, job_id, job_group_id, suite_name, test_name, classname, status,
+        duration_ms, failure_message, failure_type, stdout, stderr,
+        created_at
+    FROM chola.test_results_archive
+    WHERE job_group_id = ANY(group_ids);
+
+    INSERT INTO chola.approval_gates (
+        id, job_group_id, stage_config_id, status, required_role,
+        requested_at, responded_at, responded_by, timeout_minutes, comment
+    )
+    SELECT
+        id, job_group_id, stage_config_id, status, required_role,
+        requested_at, responded_at, responded_by, timeout_minutes, comment
+    FROM chola.approval_gates_archive
+    WHERE job_group_id = ANY(group_ids);
+
+    -- Now strip the archive rows.
+    DELETE FROM chola.approval_gates_archive      WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.test_results_archive        WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.artifacts_archive           WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.worker_reservations_archive WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.jobs_archive                WHERE job_group_id = ANY(group_ids);
+    DELETE FROM chola.job_groups_archive          WHERE id            = ANY(group_ids);
+
+    RETURN affected;
+END;
+$fn$;
+
+COMMIT;


### PR DESCRIPTION
Closes #24

## Summary
Makes the controller's reservation path support the Jenkins reservation-driven
local/cloud split, fixes a multi-stage completion bug, and reworks the build
detail / list UI around reserved stages.

## Controller
- **refactor:** hoist repo lookup, stage validation, idempotency-cache lookup,
  and `stage_deps`/`build_stage_info` above worker selection so an invalid or
  already-cached request never holds a worker.
- **feat:** silent-filter unknown stages instead of rejecting — reserve the
  known subset, list dropped names in the message; all-unknown short-circuits to
  success-with-empty (no worker, no DB row, no Redis key).
- **fix:** wait for **all** reserved stages before marking a group terminal.
  `do_reserve_worker` persists the granted manifest to `job_groups.reserved_stages`
  (migration 034, mirrored on the archive table + archive/unarchive functions);
  `check_group_completion` requires every reserved stage to have a terminal
  submitted job. Unrun stages keep the group `running` until
  `workers.stall_timeout_secs` reaps it. Failure/cancellation still collapse
  immediately.
- **feat:** typed REST response (`TriggerResponse`) — `Option<String>` for
  `job_group_id`/`worker_id` (→ JSON `null`) plus a `skipped_stages` array.
  `GET /job-groups/:id` now returns the true `reserved_stages` + derived
  `submitted_stages`.

## Frontend
- **Reserved-stages panel** on the build detail page (N/M submitted, per-stage
  status, "Pending" until submitted).
- **Running animation:** spinner on the `running` StatusBadge; marching-stripes
  fill on the stage bar.
- **Timeout-anchored bars:** each stage bar fills `elapsed / max_duration_secs`
  (stable, no sibling rescaling); per-stage time shown next to the stage name.
- **Timers & Resources** combined into one compact card (resources strip in the
  header, two timer groups side-by-side); stays visible after terminal as a
  post-mortem.
- **Clickable build rows:** whole `<tr>` navigates; ID keeps a real link for
  cmd/middle-click + keyboard.

## Migration
`migrations/034_reserved_stages.sql` — additive `reserved_stages TEXT[]` on
`job_groups` + `job_groups_archive`, plus `CREATE OR REPLACE` of the
archive/unarchive functions. NULL on pre-existing rows → legacy completion
behaviour (backward-compatible). Already applied to the local DB.

## Test plan
- [ ] `POST /job-groups` with `[checkout-scm, vira-ci, gitleaks]` → 200, granted
      `[vira-ci, gitleaks]`, `skipped_stages: ["checkout-scm"]`
- [ ] All-unknown stages → 200, `job_group_id: null`, no DB row created
- [ ] `[test, checkout-scm]`: submit `test` → group `running`; then
      `checkout-scm` → group `success`
- [ ] Reserve and submit nothing → group `Expired` after `stall_timeout_secs`
- [ ] Legacy job runner invocation `--workspace-path X --command vira-ci` still
      works (backward-compat)
- [ ] `/builds` rows clickable anywhere; cmd-click on ID opens new tab
- [ ] Build detail: reserved-stages panel, spinner + stripes on running stage,
      timeout-anchored bar, combined Timers & Resources card persists post-terminal