### PR TITLE
26: pipeline explorer and scratch root cleanup correctness

### DIFF
--- a/JustFile
+++ b/JustFile
@@ -30,12 +30,14 @@ fmt:
 
 # ─── Controller ───────────────────────────────────────────────────────────────
 
+# Local dev binds HTTP to 0.0.0.0 (reachable over LAN/Tailscale); prod keeps
+# the config default of 127.0.0.1.
 controller:
-    cargo run -p chola-controller -- --config config/controller.example.yaml
+    cargo run -p chola-controller -- --config config/controller.example.yaml --http-bind 0.0.0.0
 
 # Auto-restart controller on code change
 watch-controller:
-    cargo watch -x 'run -p chola-controller -- --config config/controller.example.yaml' -w crates/ci-controller -w crates/ci-core -i '*.log'
+    cargo watch -x 'run -p chola-controller -- --config config/controller.example.yaml --http-bind 0.0.0.0' -w crates/ci-controller -w crates/ci-core -i '*.log'
 # ─── Worker ───────────────────────────────────────────────────────────────────
 
 # Usage:
@@ -153,9 +155,10 @@ submit-auto cmd:
 frontend-install:
     cd frontend && npm install
 
-# Start frontend dev server (proxy to controller:8080)
+# Start frontend dev server (proxy to controller:8080).
+# VITE_HOST=true exposes it on 0.0.0.0 for LAN/Tailscale access in local dev.
 frontend-dev:
-    cd frontend && npm run dev
+    cd frontend && VITE_HOST=true npm run dev
 
 # Build frontend for production
 frontend-build:

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -8,13 +8,7 @@ http_port: 8080
 #   "100.x.y.z"    the host's Tailscale IP — exposed only over the tailnet (best)
 # Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
 http_bind_address: "127.0.0.1"
-
-# Directory of the built frontend (Vite `dist/`). When set, the controller
-# serves the dashboard as a SPA on http_port alongside the API — one service,
-# one port. Leave UNSET for local dev: run the Vite dev server instead
-# (`just frontend-dev` on :3000, live HMR) and use the controller for the API.
-# In prod this is wired via CHOLA_FRONTEND_DIR in run-controller.sh.
-# frontend_dir: "/var/lib/chola/frontend/dist"
+frontend_dir: "frontend/dist"
 
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -8,6 +8,7 @@ http_port: 8080
 #   "100.x.y.z"    the host's Tailscale IP — exposed only over the tailnet (best)
 # Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
 http_bind_address: "127.0.0.1"
+frontend_dir: "frontend/dist"
 
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -8,7 +8,13 @@ http_port: 8080
 #   "100.x.y.z"    the host's Tailscale IP — exposed only over the tailnet (best)
 # Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
 http_bind_address: "127.0.0.1"
-frontend_dir: "frontend/dist"
+
+# Directory of the built frontend (Vite `dist/`). When set, the controller
+# serves the dashboard as a SPA on http_port alongside the API — one service,
+# one port. Leave UNSET for local dev: run the Vite dev server instead
+# (`just frontend-dev` on :3000, live HMR) and use the controller for the API.
+# In prod this is wired via CHOLA_FRONTEND_DIR in run-controller.sh.
+# frontend_dir: "/var/lib/chola/frontend/dist"
 
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -9,6 +9,14 @@ http_port: 8080
 # Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
 http_bind_address: "127.0.0.1"
 
+# Extra browser origins allowed to send mutating (POST/PUT/DELETE) requests.
+# Same-origin is ALWAYS allowed, so the dashboard already works over localhost,
+# the machine IP, or a Tailscale host with NO config here. Only set this for a
+# separately-hosted dashboard (cross-origin). Exact match. Also settable via the
+# CHOLA_ALLOWED_ORIGINS env var (comma-separated).
+# allowed_origins:
+#   - "https://ci.example.com"
+
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.
 # Without TLS, credentials and tokens are transmitted in plaintext.

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -8,7 +8,6 @@ http_port: 8080
 #   "100.x.y.z"    the host's Tailscale IP — exposed only over the tailnet (best)
 # Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
 http_bind_address: "127.0.0.1"
-frontend_dir: "frontend/dist"
 
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.

--- a/config/controller.example.yaml
+++ b/config/controller.example.yaml
@@ -1,6 +1,14 @@
 bind_address: "0.0.0.0:50051"
 http_port: 8080
 
+# Interface the REST/HTTP server (dashboard + API) binds to.
+# Default is 127.0.0.1 (loopback only — secure by default).
+# To reach it over LAN or Tailscale, set one of:
+#   "0.0.0.0"      all interfaces (relies on token auth + firewall/VPN)
+#   "100.x.y.z"    the host's Tailscale IP — exposed only over the tailnet (best)
+# Leave as 127.0.0.1 and put a reverse proxy (nginx/Traefik) in front for prod.
+http_bind_address: "127.0.0.1"
+
 # Optional TLS for the REST API (HTTP server). Leave commented out for plain HTTP (dev).
 # For production with auth enabled: configure http_tls OR use a reverse proxy (nginx) with TLS.
 # Without TLS, credentials and tokens are transmitted in plaintext.

--- a/crates/ci-controller/src/api/job_group_handlers.rs
+++ b/crates/ci-controller/src/api/job_group_handlers.rs
@@ -347,6 +347,10 @@ pub async fn get_one(
                 "id": j.id.to_string(),
                 "stage_name": j.stage_name,
                 "command": j.command,
+                // pre/post script bodies so the UI can show pre/cmd/post as
+                // distinct pipeline steps (empty when the stage has none).
+                "pre_script": j.pre_script,
+                "post_script": j.post_script,
                 "worker_id": j.worker_id,
                 "state": j.state,
                 "exit_code": j.exit_code,

--- a/crates/ci-controller/src/api/job_group_handlers.rs
+++ b/crates/ci-controller/src/api/job_group_handlers.rs
@@ -248,18 +248,17 @@ pub async fn get_one(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::NotFound("Job group not found".into()))?;
 
-    // Look up repo name
-    let repo_name = if let Some(rid) = group.repo_id {
-        storage
-            .get_repo(rid)
-            .await
-            .ok()
-            .flatten()
-            .map(|r| r.repo_name)
-            .unwrap_or_default()
+    // Look up the repo once — used for repo_name AND the global pre/post
+    // scripts (so the UI can render global script nodes with scope).
+    let repo = if let Some(rid) = group.repo_id {
+        storage.get_repo(rid).await.ok().flatten()
     } else {
-        String::new()
+        None
     };
+    let repo_name = repo
+        .as_ref()
+        .map(|r| r.repo_name.clone())
+        .unwrap_or_default();
 
     // The granted stage manifest (set at reservation time, post silent-
     // filter). Empty for legacy rows from before migration 034 — fall
@@ -521,6 +520,13 @@ pub async fn get_one(
         "status_reason": group.status_reason,
         "reserved_stages": reserved_stages,
         "submitted_stages": submitted_stages,
+        // Repo-level global pre/post scripts + scope (worker|controller|both)
+        // so the UI can show global script nodes that expand into the
+        // controller/worker variants.
+        "global_pre_script": repo.as_ref().and_then(|r| r.global_pre_script.clone()),
+        "global_pre_script_scope": repo.as_ref().map(|r| r.global_pre_script_scope.clone()),
+        "global_post_script": repo.as_ref().and_then(|r| r.global_post_script.clone()),
+        "global_post_script_scope": repo.as_ref().map(|r| r.global_post_script_scope.clone()),
         "allocated_resources": alloc_json,
         "created_at": group.created_at.to_rfc3339(),
         "updated_at": group.updated_at.to_rfc3339(),

--- a/crates/ci-controller/src/api/worker_handlers.rs
+++ b/crates/ci-controller/src/api/worker_handlers.rs
@@ -144,7 +144,10 @@ pub async fn list(
                         "available_disk_mb": 0,
                         "disk_type": row.disk_type.as_deref().unwrap_or("unknown"),
                         "docker_enabled": row.docker_enabled,
-                        "supported_job_types": row.supported_job_types,
+                        // Default null -> [] so the API always returns an
+                        // array (the live-worker path already does); avoids
+                        // null.map() crashes in clients.
+                        "supported_job_types": row.supported_job_types.clone().unwrap_or_default(),
                         "registered_at": row.registered_at.to_rfc3339(),
                         "last_heartbeat": row.last_heartbeat_at.map(|t| json!({ "timestamp": t.to_rfc3339() })),
                         "disk_details": [],

--- a/crates/ci-controller/src/csrf.rs
+++ b/crates/ci-controller/src/csrf.rs
@@ -1,36 +1,117 @@
+use std::sync::Arc;
+
 use axum::{
     body::Body,
-    http::{Method, Request, StatusCode},
+    extract::State,
+    http::{HeaderMap, Method, Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
+    Json,
 };
+use serde_json::json;
 
-/// Reject cross-origin POST/PUT/DELETE unless Origin is localhost or absent.
-/// Webhooks are exempt — they come from external services.
-pub async fn csrf_middleware(req: Request<Body>, next: Next) -> Response {
-    let method = req.method().clone();
-    let path = req.uri().path().to_owned();
-
-    let is_mutating = matches!(method, Method::POST | Method::PUT | Method::DELETE);
-    let is_webhook = path.starts_with("/api/v1/webhooks");
+/// Reject cross-site mutating requests (CSRF). A request is allowed when:
+///   - it's not mutating (GET/HEAD/OPTIONS), or it's a webhook (external callers), or
+///   - it has no `Origin` header (non-browser clients / same-origin form posts), or
+///   - it's **same-origin**: the `Origin` host matches the host the request
+///     arrived on (`X-Forwarded-Host` from the proxy, else `Host`) — so any host
+///     you serve the dashboard on (localhost, the machine IP, a Tailscale name)
+///     works with no configuration, or
+///   - the `Origin` is in the configured `allowed_origins` list (cross-origin opt-in).
+pub async fn csrf_middleware(
+    State(allowed): State<Arc<Vec<String>>>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let is_mutating = matches!(*req.method(), Method::POST | Method::PUT | Method::DELETE);
+    let is_webhook = req.uri().path().starts_with("/api/v1/webhooks");
 
     if is_mutating && !is_webhook {
-        let origin = req
-            .headers()
+        let headers = req.headers();
+        let origin = headers
             .get("origin")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
 
-        let allowed = origin.is_empty()
-            || origin.starts_with("http://localhost:")
-            || origin.starts_with("https://localhost:")
-            || origin == "http://localhost"
-            || origin == "https://localhost";
-
-        if !allowed {
-            return StatusCode::FORBIDDEN.into_response();
+        if !origin.is_empty() && !origin_allowed(origin, headers, &allowed) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(json!({ "error": "Cross-origin request blocked" })),
+            )
+                .into_response();
         }
     }
 
     next.run(req).await
+}
+
+/// True if `origin` is same-origin with the incoming request (its host equals
+/// `X-Forwarded-Host` or `Host`), or is an exact match in the allowlist.
+pub fn origin_allowed(origin: &str, headers: &HeaderMap, allowed: &[String]) -> bool {
+    if allowed.iter().any(|a| a == origin) {
+        return true;
+    }
+    let origin_host = origin.split_once("://").map(|(_, h)| h).unwrap_or(origin);
+    let req_host = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get("host"))
+        .and_then(|v| v.to_str().ok())
+        .map(|h| h.split(',').next().unwrap_or(h).trim())
+        .unwrap_or("");
+    !req_host.is_empty() && origin_host.eq_ignore_ascii_case(req_host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::origin_allowed;
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            let name: HeaderName = k.parse().unwrap();
+            let val: HeaderValue = v.parse().unwrap();
+            h.insert(name, val);
+        }
+        h
+    }
+
+    #[test]
+    fn same_origin_via_host_allowed() {
+        // localhost and any other host both pass when Origin == Host.
+        let h = headers(&[("host", "localhost:3000")]);
+        assert!(origin_allowed("http://localhost:3000", &h, &[]));
+        let h = headers(&[("host", "dashboard.local:3000")]);
+        assert!(origin_allowed("http://dashboard.local:3000", &h, &[]));
+    }
+
+    #[test]
+    fn same_origin_via_forwarded_host_allowed() {
+        // Behind a proxy that rewrites Host: X-Forwarded-Host carries the real host.
+        let h = headers(&[
+            ("host", "localhost:8080"),
+            ("x-forwarded-host", "dashboard.local:3000"),
+        ]);
+        assert!(origin_allowed("http://dashboard.local:3000", &h, &[]));
+    }
+
+    #[test]
+    fn cross_origin_blocked() {
+        let h = headers(&[("host", "dashboard.local:3000")]);
+        assert!(!origin_allowed("http://evil.example.com", &h, &[]));
+    }
+
+    #[test]
+    fn allowlisted_cross_origin_allowed() {
+        let h = headers(&[("host", "localhost:8080")]);
+        let allowed = vec!["https://ci.example.com".to_string()];
+        assert!(origin_allowed("https://ci.example.com", &h, &allowed));
+        assert!(!origin_allowed("https://other.example.com", &h, &allowed));
+    }
+
+    #[test]
+    fn no_host_header_blocks_nonlisted_origin() {
+        let h = headers(&[]);
+        assert!(!origin_allowed("http://localhost:3000", &h, &[]));
+    }
 }

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -261,9 +261,8 @@ mod tests {
 }
 
 /// Build a `JobAssignment` proto from a domain `Job`. `group_created_at`
-/// is the parent group's RFC3339 creation timestamp, used by the worker
-/// to pick between the new unified scratch root and the legacy paths.
-/// Empty string means "unknown — fall through to legacy".
+/// is preserved for older workers, but current grouped jobs always resolve
+/// under the unified scratch root on the worker.
 fn build_job_assignment(job: Job, group_created_at: String) -> JobAssignment {
     JobAssignment {
         job_id: job.job_id,

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -207,6 +207,45 @@ pub async fn dispatch_global_post_script(
     }
 }
 
+fn prepend_global_pre_script(global_pre: &str, stage_pre: &str) -> String {
+    let mut script = String::from(
+        "if [ \"${CHOLA_STAGE_DIR+x}\" = x ]; then\n\
+__CHOLA_STAGE_DIR_SAVED=\"$CHOLA_STAGE_DIR\"\n\
+unset CHOLA_STAGE_DIR\n\
+else\n\
+__CHOLA_STAGE_DIR_SAVED=\"\"\n\
+fi\n",
+    );
+    script.push_str(global_pre);
+    if !global_pre.ends_with('\n') {
+        script.push('\n');
+    }
+    script.push_str(
+        "if [ -n \"$__CHOLA_STAGE_DIR_SAVED\" ]; then\n\
+export CHOLA_STAGE_DIR=\"$__CHOLA_STAGE_DIR_SAVED\"\n\
+else\n\
+unset CHOLA_STAGE_DIR\n\
+fi\n\
+unset __CHOLA_STAGE_DIR_SAVED\n",
+    );
+    script.push_str(stage_pre);
+    script
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepend_global_pre_script;
+
+    #[test]
+    fn prepended_global_pre_unsets_stage_dir_then_restores_it() {
+        let script = prepend_global_pre_script("echo global", "echo stage");
+        assert!(script.contains("unset CHOLA_STAGE_DIR"));
+        assert!(script.contains("export CHOLA_STAGE_DIR=\"$__CHOLA_STAGE_DIR_SAVED\""));
+        assert!(script.contains("echo global"));
+        assert!(script.contains("echo stage"));
+    }
+}
+
 /// Build a `JobAssignment` proto from a domain `Job`. `group_created_at`
 /// is the parent group's RFC3339 creation timestamp, used by the worker
 /// to pick between the new unified scratch root and the legacy paths.
@@ -1373,9 +1412,9 @@ async fn do_submit_stage(
                         };
                         if is_first {
                             if pre_script.is_empty() {
-                                pre_script = g_pre_body.clone();
+                                pre_script = prepend_global_pre_script(g_pre_body, "");
                             } else {
-                                pre_script = format!("{}\n{}", g_pre_body, pre_script);
+                                pre_script = prepend_global_pre_script(g_pre_body, &pre_script);
                             }
                             // Use global pre-script lock if stage doesn't have its own
                             if pre_lock.is_none() && repo.global_pre_script_lock_enabled {

--- a/crates/ci-controller/src/grpc_server.rs
+++ b/crates/ci-controller/src/grpc_server.rs
@@ -214,6 +214,12 @@ __CHOLA_STAGE_DIR_SAVED=\"$CHOLA_STAGE_DIR\"\n\
 unset CHOLA_STAGE_DIR\n\
 else\n\
 __CHOLA_STAGE_DIR_SAVED=\"\"\n\
+fi\n\
+if [ \"${CHOLA_STAGE_NAME+x}\" = x ]; then\n\
+__CHOLA_STAGE_NAME_SAVED=\"$CHOLA_STAGE_NAME\"\n\
+unset CHOLA_STAGE_NAME\n\
+else\n\
+__CHOLA_STAGE_NAME_SAVED=\"\"\n\
 fi\n",
     );
     script.push_str(global_pre);
@@ -226,7 +232,13 @@ export CHOLA_STAGE_DIR=\"$__CHOLA_STAGE_DIR_SAVED\"\n\
 else\n\
 unset CHOLA_STAGE_DIR\n\
 fi\n\
-unset __CHOLA_STAGE_DIR_SAVED\n",
+unset __CHOLA_STAGE_DIR_SAVED\n\
+if [ -n \"$__CHOLA_STAGE_NAME_SAVED\" ]; then\n\
+export CHOLA_STAGE_NAME=\"$__CHOLA_STAGE_NAME_SAVED\"\n\
+else\n\
+unset CHOLA_STAGE_NAME\n\
+fi\n\
+unset __CHOLA_STAGE_NAME_SAVED\n",
     );
     script.push_str(stage_pre);
     script
@@ -241,6 +253,8 @@ mod tests {
         let script = prepend_global_pre_script("echo global", "echo stage");
         assert!(script.contains("unset CHOLA_STAGE_DIR"));
         assert!(script.contains("export CHOLA_STAGE_DIR=\"$__CHOLA_STAGE_DIR_SAVED\""));
+        assert!(script.contains("unset CHOLA_STAGE_NAME"));
+        assert!(script.contains("export CHOLA_STAGE_NAME=\"$__CHOLA_STAGE_NAME_SAVED\""));
         assert!(script.contains("echo global"));
         assert!(script.contains("echo stage"));
     }

--- a/crates/ci-controller/src/http_server.rs
+++ b/crates/ci-controller/src/http_server.rs
@@ -1,13 +1,12 @@
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::http::{HeaderName, HeaderValue, Uri};
+use axum::http::{HeaderName, HeaderValue};
 use axum::middleware;
 use axum::{
     extract::State,
     http::{Method, StatusCode},
-    response::{IntoResponse, Response},
+    response::IntoResponse,
     routing::get,
     Json, Router,
 };
@@ -56,7 +55,7 @@ async fn metrics_handler(State(state): State<Arc<ControllerState>>) -> impl Into
 // Router builder
 // ---------------------------------------------------------------------------
 
-fn build_app(state: Arc<ControllerState>, frontend_dir: Option<PathBuf>) -> Router {
+fn build_app(state: Arc<ControllerState>) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _| {
             let s = origin.to_str().unwrap_or("");
@@ -96,63 +95,10 @@ fn build_app(state: Arc<ControllerState>, frontend_dir: Option<PathBuf>) -> Rout
             .url("/api-docs/openapi.json", crate::openapi::ApiDoc::openapi()),
     );
 
-    let base = base.layer(middleware::from_fn(csrf_middleware)).layer(cors);
-
-    // When a built frontend is configured, serve it as a SPA from the
-    // fallback; otherwise keep the JSON 404 (API-only). Canonicalize the dir
-    // once so the per-request traversal check is a cheap prefix compare.
-    let app = match frontend_dir.and_then(|d| std::fs::canonicalize(d).ok()) {
-        Some(dir) if dir.is_dir() => {
-            info!("Serving frontend from {}", dir.display());
-            let index = dir.join("index.html");
-            base.fallback(move |uri: Uri| {
-                let dir = dir.clone();
-                let index = index.clone();
-                async move { serve_spa(uri, dir, index).await }
-            })
-        }
-        _ => base.fallback(fallback_handler),
-    };
-    app.with_state(state)
-}
-
-/// SPA fallback: serve a static file from `dir` if it exists (and is safely
-/// under `dir`), otherwise `index.html` so client-side routes resolve. API /
-/// infra paths never fall back to HTML — they get a JSON 404.
-async fn serve_spa(uri: Uri, dir: PathBuf, index: PathBuf) -> Response {
-    let path = uri.path();
-    if path.starts_with("/api")
-        || path.starts_with("/health")
-        || path == "/metrics"
-        || path.starts_with("/swagger-ui")
-        || path.starts_with("/api-docs")
-    {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": format!("Route not found: {}", path) })),
-        )
-            .into_response();
-    }
-
-    // Resolve the requested file; fall back to index.html for SPA routes and
-    // reject path traversal (canonical path must stay under `dir`).
-    let candidate = dir.join(path.trim_start_matches('/'));
-    let serve_path = match tokio::fs::canonicalize(&candidate).await {
-        Ok(c) if c.starts_with(&dir) && c.is_file() => c,
-        _ => index,
-    };
-
-    match tokio::fs::read(&serve_path).await {
-        Ok(bytes) => {
-            let mime = mime_guess::from_path(&serve_path).first_or_octet_stream();
-            ([(axum::http::header::CONTENT_TYPE, mime.as_ref())], bytes).into_response()
-        }
-        Err(_) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": "frontend index.html not found" })),
-        )
-            .into_response(),
-    }
+    base.layer(middleware::from_fn(csrf_middleware))
+        .layer(cors)
+        .fallback(fallback_handler)
+        .with_state(state)
 }
 
 /// Middleware: if the response is a 4xx/5xx with non-JSON content-type, wrap in JSON.
@@ -196,9 +142,8 @@ pub async fn run(
     http_addr: SocketAddr,
     state: Arc<ControllerState>,
     tls_config: Option<TlsServerConfig>,
-    frontend_dir: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    let app = build_app(state, frontend_dir);
+    let app = build_app(state);
     match tls_config {
         Some(tls) if tls.enabled => serve_tls(http_addr, app, &tls).await,
         _ => serve_plain(http_addr, app).await,

--- a/crates/ci-controller/src/http_server.rs
+++ b/crates/ci-controller/src/http_server.rs
@@ -56,11 +56,18 @@ async fn metrics_handler(State(state): State<Arc<ControllerState>>) -> impl Into
 // ---------------------------------------------------------------------------
 
 fn build_app(state: Arc<ControllerState>) -> Router {
+    // Same-origin is always allowed (works over localhost, the machine IP, or a
+    // Tailscale host with no config); `allowed_origins` adds cross-origin opt-ins.
+    let allowed_origins = Arc::new(state.config.allowed_origins.clone());
+
+    let cors_origins = allowed_origins.clone();
     let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _| {
-            let s = origin.to_str().unwrap_or("");
-            s.starts_with("http://localhost:") || s.starts_with("https://localhost:")
-        }))
+        .allow_origin(AllowOrigin::predicate(
+            move |origin: &HeaderValue, parts: &axum::http::request::Parts| {
+                let s = origin.to_str().unwrap_or("");
+                crate::csrf::origin_allowed(s, &parts.headers, &cors_origins)
+            },
+        ))
         .allow_methods([
             Method::GET,
             Method::POST,
@@ -95,10 +102,13 @@ fn build_app(state: Arc<ControllerState>) -> Router {
             .url("/api-docs/openapi.json", crate::openapi::ApiDoc::openapi()),
     );
 
-    base.layer(middleware::from_fn(csrf_middleware))
-        .layer(cors)
-        .fallback(fallback_handler)
-        .with_state(state)
+    base.layer(middleware::from_fn_with_state(
+        allowed_origins,
+        csrf_middleware,
+    ))
+    .layer(cors)
+    .fallback(fallback_handler)
+    .with_state(state)
 }
 
 /// Middleware: if the response is a 4xx/5xx with non-JSON content-type, wrap in JSON.

--- a/crates/ci-controller/src/http_server.rs
+++ b/crates/ci-controller/src/http_server.rs
@@ -1,12 +1,13 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::http::{HeaderName, HeaderValue};
+use axum::http::{HeaderName, HeaderValue, Uri};
 use axum::middleware;
 use axum::{
     extract::State,
     http::{Method, StatusCode},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
@@ -55,7 +56,7 @@ async fn metrics_handler(State(state): State<Arc<ControllerState>>) -> impl Into
 // Router builder
 // ---------------------------------------------------------------------------
 
-fn build_app(state: Arc<ControllerState>) -> Router {
+fn build_app(state: Arc<ControllerState>, frontend_dir: Option<PathBuf>) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _| {
             let s = origin.to_str().unwrap_or("");
@@ -95,10 +96,63 @@ fn build_app(state: Arc<ControllerState>) -> Router {
             .url("/api-docs/openapi.json", crate::openapi::ApiDoc::openapi()),
     );
 
-    base.layer(middleware::from_fn(csrf_middleware))
-        .layer(cors)
-        .fallback(fallback_handler)
-        .with_state(state)
+    let base = base.layer(middleware::from_fn(csrf_middleware)).layer(cors);
+
+    // When a built frontend is configured, serve it as a SPA from the
+    // fallback; otherwise keep the JSON 404 (API-only). Canonicalize the dir
+    // once so the per-request traversal check is a cheap prefix compare.
+    let app = match frontend_dir.and_then(|d| std::fs::canonicalize(d).ok()) {
+        Some(dir) if dir.is_dir() => {
+            info!("Serving frontend from {}", dir.display());
+            let index = dir.join("index.html");
+            base.fallback(move |uri: Uri| {
+                let dir = dir.clone();
+                let index = index.clone();
+                async move { serve_spa(uri, dir, index).await }
+            })
+        }
+        _ => base.fallback(fallback_handler),
+    };
+    app.with_state(state)
+}
+
+/// SPA fallback: serve a static file from `dir` if it exists (and is safely
+/// under `dir`), otherwise `index.html` so client-side routes resolve. API /
+/// infra paths never fall back to HTML — they get a JSON 404.
+async fn serve_spa(uri: Uri, dir: PathBuf, index: PathBuf) -> Response {
+    let path = uri.path();
+    if path.starts_with("/api")
+        || path.starts_with("/health")
+        || path == "/metrics"
+        || path.starts_with("/swagger-ui")
+        || path.starts_with("/api-docs")
+    {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("Route not found: {}", path) })),
+        )
+            .into_response();
+    }
+
+    // Resolve the requested file; fall back to index.html for SPA routes and
+    // reject path traversal (canonical path must stay under `dir`).
+    let candidate = dir.join(path.trim_start_matches('/'));
+    let serve_path = match tokio::fs::canonicalize(&candidate).await {
+        Ok(c) if c.starts_with(&dir) && c.is_file() => c,
+        _ => index,
+    };
+
+    match tokio::fs::read(&serve_path).await {
+        Ok(bytes) => {
+            let mime = mime_guess::from_path(&serve_path).first_or_octet_stream();
+            ([(axum::http::header::CONTENT_TYPE, mime.as_ref())], bytes).into_response()
+        }
+        Err(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "frontend index.html not found" })),
+        )
+            .into_response(),
+    }
 }
 
 /// Middleware: if the response is a 4xx/5xx with non-JSON content-type, wrap in JSON.
@@ -142,8 +196,9 @@ pub async fn run(
     http_addr: SocketAddr,
     state: Arc<ControllerState>,
     tls_config: Option<TlsServerConfig>,
+    frontend_dir: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    let app = build_app(state);
+    let app = build_app(state, frontend_dir);
     match tls_config {
         Some(tls) if tls.enabled => serve_tls(http_addr, app, &tls).await,
         _ => serve_plain(http_addr, app).await,

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -64,12 +64,6 @@ struct Cli {
     /// Local dev binds 0.0.0.0 via `just`; prod keeps the config default.
     #[arg(long)]
     http_bind: Option<String>,
-
-    /// Override the built-frontend directory (from config: frontend_dir).
-    /// Prod wires this via CHOLA_FRONTEND_DIR in run-controller.sh so the
-    /// controller serves the dashboard without editing the config yaml.
-    #[arg(long)]
-    frontend_dir: Option<String>,
 }
 
 #[tokio::main]
@@ -94,9 +88,6 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(http_bind) = cli.http_bind {
         config.http_bind_address = http_bind;
-    }
-    if let Some(frontend_dir) = cli.frontend_dir {
-        config.frontend_dir = Some(frontend_dir);
     }
 
     let log_level = cli.log_level.as_deref().unwrap_or(&config.logging.level);

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -64,6 +64,12 @@ struct Cli {
     /// Local dev binds 0.0.0.0 via `just`; prod keeps the config default.
     #[arg(long)]
     http_bind: Option<String>,
+
+    /// Override the built-frontend directory (from config: frontend_dir).
+    /// Prod wires this via CHOLA_FRONTEND_DIR in run-controller.sh so the
+    /// controller serves the dashboard without editing the config yaml.
+    #[arg(long)]
+    frontend_dir: Option<String>,
 }
 
 #[tokio::main]
@@ -88,6 +94,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(http_bind) = cli.http_bind {
         config.http_bind_address = http_bind;
+    }
+    if let Some(frontend_dir) = cli.frontend_dir {
+        config.frontend_dir = Some(frontend_dir);
     }
 
     let log_level = cli.log_level.as_deref().unwrap_or(&config.logging.level);

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -558,8 +558,9 @@ async fn main() -> anyhow::Result<()> {
     {
         let http_state = state.clone();
         let http_tls = config.http_tls.clone();
+        let frontend_dir = config.frontend_dir.clone().map(std::path::PathBuf::from);
         tokio::spawn(async move {
-            if let Err(e) = http_server::run(http_addr, http_state, http_tls).await {
+            if let Err(e) = http_server::run(http_addr, http_state, http_tls, frontend_dir).await {
                 error!("HTTP server failed: {}", e);
             }
         });

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -558,9 +558,8 @@ async fn main() -> anyhow::Result<()> {
     {
         let http_state = state.clone();
         let http_tls = config.http_tls.clone();
-        let frontend_dir = config.frontend_dir.clone().map(std::path::PathBuf::from);
         tokio::spawn(async move {
-            if let Err(e) = http_server::run(http_addr, http_state, http_tls, frontend_dir).await {
+            if let Err(e) = http_server::run(http_addr, http_state, http_tls).await {
                 error!("HTTP server failed: {}", e);
             }
         });

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -59,6 +59,11 @@ struct Cli {
     /// Override HTTP sidecar port (from config: http_port)
     #[arg(long)]
     http_port: Option<u16>,
+
+    /// Override the HTTP bind interface (from config: http_bind_address).
+    /// Local dev binds 0.0.0.0 via `just`; prod keeps the config default.
+    #[arg(long)]
+    http_bind: Option<String>,
 }
 
 #[tokio::main]
@@ -80,6 +85,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(port) = cli.http_port {
         config.http_port = port;
+    }
+    if let Some(http_bind) = cli.http_bind {
+        config.http_bind_address = http_bind;
     }
 
     let log_level = cli.log_level.as_deref().unwrap_or(&config.logging.level);
@@ -105,7 +113,10 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Starting CI Controller");
     info!("Bind address: {}", config.bind_address);
-    info!("HTTP port: {}", config.http_port);
+    info!(
+        "HTTP bind: {}:{}",
+        config.http_bind_address, config.http_port
+    );
     info!("Scheduling strategy: {}", config.scheduling.strategy);
 
     // Connect to PostgreSQL (non-fatal)
@@ -542,7 +553,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Start HTTP sidecar in background
-    let http_addr: std::net::SocketAddr = format!("0.0.0.0:{}", config.http_port).parse()?;
+    let http_addr: std::net::SocketAddr =
+        format!("{}:{}", config.http_bind_address, config.http_port).parse()?;
     {
         let http_state = state.clone();
         let http_tls = config.http_tls.clone();

--- a/crates/ci-controller/src/main.rs
+++ b/crates/ci-controller/src/main.rs
@@ -89,6 +89,17 @@ async fn main() -> anyhow::Result<()> {
     if let Some(http_bind) = cli.http_bind {
         config.http_bind_address = http_bind;
     }
+    // CHOLA_ALLOWED_ORIGINS (comma-separated) adds cross-origin opt-ins on top
+    // of config. Same-origin needs no config; this is only for a separately
+    // hosted dashboard. Lets `just`/systemd pass origins via env.
+    if let Ok(origins) = std::env::var("CHOLA_ALLOWED_ORIGINS") {
+        config.allowed_origins.extend(
+            origins
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
+        );
+    }
 
     let log_level = cli.log_level.as_deref().unwrap_or(&config.logging.level);
 

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -4746,8 +4746,15 @@ impl Storage {
     /// Deactivate all active tokens bound to a specific worker_id.
     /// Returns the number of rows updated.
     pub async fn deactivate_tokens_for_worker(&self, worker_id: &str) -> anyhow::Result<u64> {
+        // Also clear worker_id: the partial unique index
+        // `idx_worker_tokens_worker_id (worker_id) WHERE worker_id IS NOT NULL`
+        // is NOT scoped to `active`, so a deactivated row that still carries
+        // worker_id would block the fresh token insert during regeneration
+        // (duplicate key violation -> HTTP 500). A revoked token has no need
+        // for its worker binding.
         let result = sqlx::query(
-            "UPDATE worker_tokens SET active = false WHERE worker_id = $1 AND active = true",
+            "UPDATE worker_tokens SET active = false, worker_id = NULL \
+             WHERE worker_id = $1 AND active = true",
         )
         .bind(worker_id)
         .execute(&self.pool)

--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -4839,7 +4839,17 @@ impl Storage {
         .execute(&mut *tx)
         .await?;
 
-        // 2. Create worker_token row with worker_id binding
+        // 2. Clear any pre-existing token bound to this worker_id. The unique
+        // index `idx_worker_tokens_worker_id (worker_id) WHERE worker_id IS
+        // NOT NULL` would otherwise reject the insert below (e.g. an orphan
+        // token left over from a prior registration). Re-registration always
+        // mints a fresh token, so dropping the old binding is correct.
+        sqlx::query("DELETE FROM worker_tokens WHERE worker_id = $1")
+            .bind(worker_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // 3. Create worker_token row with worker_id binding
         sqlx::query(
             "INSERT INTO worker_tokens (name, token_hash, scope, created_by, worker_id) \
              VALUES ($1, $2, 'dedicated', $3, $4)",
@@ -4992,10 +5002,21 @@ impl Storage {
     }
 
     pub async fn delete_worker(&self, worker_id: &str) -> anyhow::Result<bool> {
+        // There is no FK cascade from worker_tokens -> workers, so deleting
+        // the worker alone would orphan its token rows. A leftover token
+        // still carries worker_id and would then collide with the unique
+        // index `idx_worker_tokens_worker_id` on the next registration. Drop
+        // the worker's tokens in the same transaction.
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM worker_tokens WHERE worker_id = $1")
+            .bind(worker_id)
+            .execute(&mut *tx)
+            .await?;
         let result = sqlx::query("DELETE FROM workers WHERE worker_id = $1")
             .bind(worker_id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/crates/ci-core/src/models/config.rs
+++ b/crates/ci-core/src/models/config.rs
@@ -31,6 +31,12 @@ pub struct ControllerConfig {
     /// exposed only over the tailnet.
     #[serde(default = "default_http_bind_address")]
     pub http_bind_address: String,
+    /// Directory of the built frontend (Vite `dist/`). When set and it
+    /// exists, the HTTP server serves it as a SPA (static assets + index.html
+    /// fallback for client routes), so no separate frontend service is
+    /// needed. Unset (default) = API only.
+    #[serde(default)]
+    pub frontend_dir: Option<String>,
     #[serde(default)]
     pub retention: Option<RetentionConfig>,
 }

--- a/crates/ci-core/src/models/config.rs
+++ b/crates/ci-core/src/models/config.rs
@@ -31,6 +31,14 @@ pub struct ControllerConfig {
     /// exposed only over the tailnet.
     #[serde(default = "default_http_bind_address")]
     pub http_bind_address: String,
+    /// Extra browser origins allowed to send mutating (POST/PUT/DELETE)
+    /// requests, on top of same-origin — which is ALWAYS allowed, so the
+    /// dashboard works over localhost, the machine IP, or a Tailscale host with
+    /// no config at all. Only needed for cross-origin setups (e.g. a
+    /// separately-hosted dashboard). Exact match, e.g. "https://ci.example.com".
+    /// Also settable via the CHOLA_ALLOWED_ORIGINS env var (comma-separated).
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
     #[serde(default)]
     pub retention: Option<RetentionConfig>,
 }

--- a/crates/ci-core/src/models/config.rs
+++ b/crates/ci-core/src/models/config.rs
@@ -23,12 +23,24 @@ pub struct ControllerConfig {
     pub auth: AuthConfig,
     #[serde(default = "default_controller_http_port")]
     pub http_port: u16,
+    /// Interface the REST/HTTP server binds to. Defaults to loopback
+    /// (127.0.0.1) — secure by default. To reach the dashboard/API over
+    /// LAN or Tailscale, set this explicitly: either "0.0.0.0" (all
+    /// interfaces; relies on token auth + your firewall/VPN as the
+    /// boundary), or, best, the host's Tailscale IP "100.x.y.z" so it's
+    /// exposed only over the tailnet.
+    #[serde(default = "default_http_bind_address")]
+    pub http_bind_address: String,
     #[serde(default)]
     pub retention: Option<RetentionConfig>,
 }
 
 fn default_controller_http_port() -> u16 {
     8080
+}
+
+fn default_http_bind_address() -> String {
+    "127.0.0.1".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/ci-core/src/models/config.rs
+++ b/crates/ci-core/src/models/config.rs
@@ -31,12 +31,6 @@ pub struct ControllerConfig {
     /// exposed only over the tailnet.
     #[serde(default = "default_http_bind_address")]
     pub http_bind_address: String,
-    /// Directory of the built frontend (Vite `dist/`). When set and it
-    /// exists, the HTTP server serves it as a SPA (static assets + index.html
-    /// fallback for client routes), so no separate frontend service is
-    /// needed. Unset (default) = API only.
-    #[serde(default)]
-    pub frontend_dir: Option<String>,
     #[serde(default)]
     pub retention: Option<RetentionConfig>,
 }

--- a/crates/ci-worker/src/agent.rs
+++ b/crates/ci-worker/src/agent.rs
@@ -487,11 +487,9 @@ async fn handle_job_assignment(
         .cloned()
         .collect();
 
-    // Per-build workspace + log path. The new layout
-    // (`<scratch_root>/<gid>/...`) kicks in when the group was created
-    // at-or-after this worker process booted. The controller populates
-    // `assignment.group_created_at` as RFC3339; empty string means
-    // "unknown" → resolver falls through to legacy paths.
+    // Grouped jobs always resolve under the unified scratch layout
+    // (`<scratch_root>/<gid>/...`). Ad-hoc jobs with no group id keep the
+    // single-job fallback layout.
     let group_created_at = if assignment.group_created_at.is_empty() {
         None
     } else {
@@ -784,6 +782,18 @@ async fn run_job_with_streaming(
         ctx.job_id, ctx.command, ctx.workspace_dir
     );
 
+    // Cleanup scripts may delete CHOLA_WORK_DIR; run the synthetic cleanup
+    // command from the group's parent scratch directory so a removed workspace
+    // does not break command startup.
+    let command_work_dir = if ctx.stage_name == "__cleanup__" {
+        std::path::Path::new(&ctx.workspace_dir)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| ctx.workspace_dir.clone())
+    } else {
+        ctx.workspace_dir.clone()
+    };
+
     // Ensure the shared build workspace directory exists.
     if let Err(e) = tokio::fs::create_dir_all(&ctx.workspace_dir).await {
         warn!(
@@ -853,7 +863,7 @@ async fn run_job_with_streaming(
                 &ctx.command,
                 &ctx.pre_script,
                 &ctx.post_script,
-                &ctx.workspace_dir,
+                &command_work_dir,
                 &log_path,
                 log_tx,
                 cancel_rx,
@@ -881,7 +891,7 @@ async fn run_job_with_streaming(
         let result = executor
             .execute_streaming(
                 &ctx.command,
-                &ctx.workspace_dir,
+                &command_work_dir,
                 &log_path,
                 log_tx,
                 cancel_rx,

--- a/crates/ci-worker/src/agent.rs
+++ b/crates/ci-worker/src/agent.rs
@@ -510,6 +510,10 @@ async fn handle_job_assignment(
         &job_id,
     );
     let workspace_dir = resolved.workspace_dir.to_string_lossy().to_string();
+    let stages_dir = resolved
+        .stages_dir
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
     let stage_dir = resolved
         .stage_dir
         .as_ref()
@@ -522,6 +526,12 @@ async fn handle_job_assignment(
     environment.insert("CHOLA_REPOS_DIR".into(), config.execution.repos_dir.clone());
     environment.insert("CHOLA_WORKSPACE_DIR".into(), workspace_dir.clone());
     environment.insert("CHOLA_WORK_DIR".into(), workspace_dir.clone());
+    if let Some(ref stages_dir) = stages_dir {
+        environment.insert("CHOLA_STAGES_DIR".into(), stages_dir.clone());
+    }
+    if !assignment.stage_name.is_empty() && assignment.stage_name != "__cleanup__" {
+        environment.insert("CHOLA_STAGE_NAME".into(), assignment.stage_name.clone());
+    }
     if let Some(ref stage_dir) = stage_dir {
         environment.insert("CHOLA_STAGE_DIR".into(), stage_dir.clone());
     }

--- a/crates/ci-worker/src/agent.rs
+++ b/crates/ci-worker/src/agent.rs
@@ -36,7 +36,8 @@ struct JobContext {
     worker_id: String,
     job_id: String,
     command: String,
-    work_dir: String,
+    workspace_dir: String,
+    stage_dir: Option<String>,
     /// Pre-resolved per-stage log path (new vs legacy layout decided up
     /// front in `handle_job_assignment`).
     log_path: String,
@@ -508,21 +509,30 @@ async fn handle_job_assignment(
         &assignment.stage_name,
         &job_id,
     );
-    let work_dir = resolved.workspace.to_string_lossy().to_string();
+    let workspace_dir = resolved.workspace_dir.to_string_lossy().to_string();
+    let stage_dir = resolved
+        .stage_dir
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
     let stage_log_path = resolved.log_path.to_string_lossy().to_string();
 
     // Build environment: assignment env + worker-local paths
     let mut environment: HashMap<String, String> =
         assignment.environment.clone().into_iter().collect();
     environment.insert("CHOLA_REPOS_DIR".into(), config.execution.repos_dir.clone());
-    environment.insert("CHOLA_WORK_DIR".into(), work_dir.clone());
+    environment.insert("CHOLA_WORKSPACE_DIR".into(), workspace_dir.clone());
+    environment.insert("CHOLA_WORK_DIR".into(), workspace_dir.clone());
+    if let Some(ref stage_dir) = stage_dir {
+        environment.insert("CHOLA_STAGE_DIR".into(), stage_dir.clone());
+    }
     environment.insert("WORKER_ID".into(), config.worker_id.clone());
 
     let ctx = JobContext {
         worker_id: config.worker_id.clone(),
         job_id: job_id.clone(),
         command: assignment.command.clone(),
-        work_dir,
+        workspace_dir,
+        stage_dir,
         log_path: stage_log_path,
         pre_script: assignment.pre_script.clone(),
         post_script: assignment.post_script.clone(),
@@ -760,13 +770,21 @@ async fn run_job_with_streaming(
     cancel_rx: mpsc::Receiver<i32>,
 ) -> ci_core::proto::orchestrator::JobState {
     info!(
-        "run_job_with_streaming: job_id={}, command={}, work_dir={}",
-        ctx.job_id, ctx.command, ctx.work_dir
+        "run_job_with_streaming: job_id={}, command={}, workspace_dir={}",
+        ctx.job_id, ctx.command, ctx.workspace_dir
     );
 
-    // Ensure per-build workspace directory exists
-    if let Err(e) = tokio::fs::create_dir_all(&ctx.work_dir).await {
-        warn!("Failed to create workspace dir {}: {}", ctx.work_dir, e);
+    // Ensure the shared build workspace directory exists.
+    if let Err(e) = tokio::fs::create_dir_all(&ctx.workspace_dir).await {
+        warn!(
+            "Failed to create workspace dir {}: {}",
+            ctx.workspace_dir, e
+        );
+    }
+    if let Some(ref stage_dir) = ctx.stage_dir {
+        if let Err(e) = tokio::fs::create_dir_all(stage_dir).await {
+            warn!("Failed to create stage dir {}: {}", stage_dir, e);
+        }
     }
 
     let has_stage_scripts = !ctx.pre_script.is_empty() || !ctx.post_script.is_empty();
@@ -825,7 +843,7 @@ async fn run_job_with_streaming(
                 &ctx.command,
                 &ctx.pre_script,
                 &ctx.post_script,
-                &ctx.work_dir,
+                &ctx.workspace_dir,
                 &log_path,
                 log_tx,
                 cancel_rx,
@@ -853,7 +871,7 @@ async fn run_job_with_streaming(
         let result = executor
             .execute_streaming(
                 &ctx.command,
-                &ctx.work_dir,
+                &ctx.workspace_dir,
                 &log_path,
                 log_tx,
                 cancel_rx,

--- a/crates/ci-worker/src/stage_runner.rs
+++ b/crates/ci-worker/src/stage_runner.rs
@@ -86,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_paths_legacy_layout_keeps_group_workspace() {
+    fn resolve_paths_grouped_jobs_always_use_scratch_layout() {
         let created = Utc.with_ymd_and_hms(2026, 8, 7, 8, 0, 0).unwrap();
         let startup = Utc.with_ymd_and_hms(2026, 8, 7, 9, 0, 0).unwrap();
 
@@ -103,13 +103,19 @@ mod tests {
 
         assert_eq!(
             resolved.workspace_dir,
-            std::path::PathBuf::from("/work/gid-1")
+            std::path::PathBuf::from("/scratch/gid-1/workspace")
         );
-        assert_eq!(resolved.stages_dir, None);
-        assert_eq!(resolved.stage_dir, None);
+        assert_eq!(
+            resolved.stages_dir,
+            Some(std::path::PathBuf::from("/scratch/gid-1/stages"))
+        );
+        assert_eq!(
+            resolved.stage_dir,
+            Some(std::path::PathBuf::from("/scratch/gid-1/stages/build"))
+        );
         assert_eq!(
             resolved.log_path,
-            std::path::PathBuf::from("/logs/gid-1/build.log")
+            std::path::PathBuf::from("/scratch/gid-1/logs/build.log")
         );
     }
 }
@@ -433,22 +439,17 @@ impl StageRunner {
         }
     }
 
-    /// Resolve the log + workspace paths for a stage, picking between the
-    /// new unified scratch layout and the legacy layout based on the
-    /// group's `created_at` vs the worker's startup timestamp.
+    /// Resolve the log + workspace paths for a stage.
     ///
-    /// New layout (group created at-or-after worker boot):
+    /// Grouped jobs always use the unified scratch layout:
     /// - log:       `<scratch_root>/<gid>/logs/<stage>.log`
     /// - workspace: `<scratch_root>/<gid>/workspace/`
     /// - stage dir: `<scratch_root>/<gid>/stages/<stage>/`
     ///
-    /// Legacy layout (group from before the upgrade, or unknown
-    /// `created_at`):
+    /// Ad-hoc jobs with no `job_group_id` keep the legacy single-job layout:
     /// - log:       `<log_dir>/<gid>/<stage>.log`
     /// - workspace: `<work_dir>/<gid>/`
     /// - stage dir: none
-    ///
-    /// See `local/docs/retention-implementation-plan.md` §3.D + §4.
     #[allow(clippy::too_many_arguments)]
     pub fn resolve_paths(
         scratch_root: &str,
@@ -460,12 +461,8 @@ impl StageRunner {
         stage_name: &str,
         job_id: &str,
     ) -> ResolvedStagePaths {
-        let use_new_layout = matches!(
-            (group_created_at, worker_startup_ts),
-            (Some(created), Some(startup)) if created >= startup,
-        );
-
-        if use_new_layout && !job_group_id.is_empty() {
+        let _ = (group_created_at, worker_startup_ts);
+        if !job_group_id.is_empty() {
             let safe_group = Self::sanitize_path_component(job_group_id);
             let group_root = PathBuf::from(scratch_root).join(&safe_group);
             let safe_stage = if stage_name.is_empty() {

--- a/crates/ci-worker/src/stage_runner.rs
+++ b/crates/ci-worker/src/stage_runner.rs
@@ -41,6 +41,10 @@ mod tests {
             std::path::PathBuf::from("/scratch/gid-1/workspace")
         );
         assert_eq!(
+            resolved.stages_dir,
+            Some(std::path::PathBuf::from("/scratch/gid-1/stages"))
+        );
+        assert_eq!(
             resolved.stage_dir,
             Some(std::path::PathBuf::from("/scratch/gid-1/stages/build"))
         );
@@ -70,6 +74,10 @@ mod tests {
             resolved.workspace_dir,
             std::path::PathBuf::from("/scratch/gid-1/workspace")
         );
+        assert_eq!(
+            resolved.stages_dir,
+            Some(std::path::PathBuf::from("/scratch/gid-1/stages"))
+        );
         assert_eq!(resolved.stage_dir, None);
         assert_eq!(
             resolved.log_path,
@@ -97,6 +105,7 @@ mod tests {
             resolved.workspace_dir,
             std::path::PathBuf::from("/work/gid-1")
         );
+        assert_eq!(resolved.stages_dir, None);
         assert_eq!(resolved.stage_dir, None);
         assert_eq!(
             resolved.log_path,
@@ -385,6 +394,7 @@ pub enum StageState {
 pub struct ResolvedStagePaths {
     pub log_path: PathBuf,
     pub workspace_dir: PathBuf,
+    pub stages_dir: Option<PathBuf>,
     pub stage_dir: Option<PathBuf>,
 }
 
@@ -465,13 +475,15 @@ impl StageRunner {
             };
             let log_path = group_root.join("logs").join(format!("{}.log", &safe_stage));
             let workspace_dir = group_root.join("workspace");
+            let stages_dir = Some(group_root.join("stages"));
             let stage_dir = match stage_name {
                 "" | "__cleanup__" => None,
-                _ => Some(group_root.join("stages").join(&safe_stage)),
+                _ => Some(stages_dir.as_ref().expect("stages dir").join(&safe_stage)),
             };
             ResolvedStagePaths {
                 log_path,
                 workspace_dir,
+                stages_dir,
                 stage_dir,
             }
         } else {
@@ -485,6 +497,7 @@ impl StageRunner {
             ResolvedStagePaths {
                 log_path,
                 workspace_dir,
+                stages_dir: None,
                 stage_dir: None,
             }
         }

--- a/crates/ci-worker/src/stage_runner.rs
+++ b/crates/ci-worker/src/stage_runner.rs
@@ -15,6 +15,96 @@ pub struct ScriptLockConfig {
     pub scope: String, // "worker" (flock) or "controller" (Redis via gRPC)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::StageRunner;
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn resolve_paths_new_layout_uses_shared_workspace_and_stage_dir() {
+        let created = Utc.with_ymd_and_hms(2026, 8, 7, 10, 0, 0).unwrap();
+        let startup = Utc.with_ymd_and_hms(2026, 8, 7, 9, 0, 0).unwrap();
+
+        let resolved = StageRunner::resolve_paths(
+            "/scratch",
+            "/logs",
+            "/work",
+            Some(created),
+            Some(startup),
+            "gid-1",
+            "build",
+            "job-1",
+        );
+
+        assert_eq!(
+            resolved.workspace_dir,
+            std::path::PathBuf::from("/scratch/gid-1/workspace")
+        );
+        assert_eq!(
+            resolved.stage_dir,
+            Some(std::path::PathBuf::from("/scratch/gid-1/stages/build"))
+        );
+        assert_eq!(
+            resolved.log_path,
+            std::path::PathBuf::from("/scratch/gid-1/logs/build.log")
+        );
+    }
+
+    #[test]
+    fn resolve_paths_cleanup_job_has_no_stage_dir() {
+        let created = Utc.with_ymd_and_hms(2026, 8, 7, 10, 0, 0).unwrap();
+        let startup = Utc.with_ymd_and_hms(2026, 8, 7, 9, 0, 0).unwrap();
+
+        let resolved = StageRunner::resolve_paths(
+            "/scratch",
+            "/logs",
+            "/work",
+            Some(created),
+            Some(startup),
+            "gid-1",
+            "__cleanup__",
+            "gid-1-__cleanup__",
+        );
+
+        assert_eq!(
+            resolved.workspace_dir,
+            std::path::PathBuf::from("/scratch/gid-1/workspace")
+        );
+        assert_eq!(resolved.stage_dir, None);
+        assert_eq!(
+            resolved.log_path,
+            std::path::PathBuf::from("/scratch/gid-1/logs/__cleanup__.log")
+        );
+    }
+
+    #[test]
+    fn resolve_paths_legacy_layout_keeps_group_workspace() {
+        let created = Utc.with_ymd_and_hms(2026, 8, 7, 8, 0, 0).unwrap();
+        let startup = Utc.with_ymd_and_hms(2026, 8, 7, 9, 0, 0).unwrap();
+
+        let resolved = StageRunner::resolve_paths(
+            "/scratch",
+            "/logs",
+            "/work",
+            Some(created),
+            Some(startup),
+            "gid-1",
+            "build",
+            "job-1",
+        );
+
+        assert_eq!(
+            resolved.workspace_dir,
+            std::path::PathBuf::from("/work/gid-1")
+        );
+        assert_eq!(resolved.stage_dir, None);
+        assert_eq!(
+            resolved.log_path,
+            std::path::PathBuf::from("/logs/gid-1/build.log")
+        );
+    }
+}
+
 impl ScriptLockConfig {
     pub fn from_proto(proto: Option<ci_core::proto::orchestrator::ScriptLockConfig>) -> Self {
         match proto {
@@ -294,7 +384,8 @@ pub enum StageState {
 #[derive(Debug, Clone)]
 pub struct ResolvedStagePaths {
     pub log_path: PathBuf,
-    pub workspace: PathBuf,
+    pub workspace_dir: PathBuf,
+    pub stage_dir: Option<PathBuf>,
 }
 
 /// Runs a complete stage: pre_script -> command -> post_script
@@ -338,12 +429,14 @@ impl StageRunner {
     ///
     /// New layout (group created at-or-after worker boot):
     /// - log:       `<scratch_root>/<gid>/logs/<stage>.log`
-    /// - workspace: `<scratch_root>/<gid>/workspace/<stage>/`
+    /// - workspace: `<scratch_root>/<gid>/workspace/`
+    /// - stage dir: `<scratch_root>/<gid>/stages/<stage>/`
     ///
     /// Legacy layout (group from before the upgrade, or unknown
     /// `created_at`):
     /// - log:       `<log_dir>/<gid>/<stage>.log`
     /// - workspace: `<work_dir>/<gid>/`
+    /// - stage dir: none
     ///
     /// See `local/docs/retention-implementation-plan.md` §3.D + §4.
     #[allow(clippy::too_many_arguments)]
@@ -364,21 +457,26 @@ impl StageRunner {
 
         if use_new_layout && !job_group_id.is_empty() {
             let safe_group = Self::sanitize_path_component(job_group_id);
+            let group_root = PathBuf::from(scratch_root).join(&safe_group);
             let safe_stage = if stage_name.is_empty() {
                 Self::sanitize_path_component(job_id)
             } else {
                 Self::sanitize_path_component(stage_name)
             };
-            let group_root = PathBuf::from(scratch_root).join(&safe_group);
             let log_path = group_root.join("logs").join(format!("{}.log", &safe_stage));
-            let workspace = group_root.join("workspace").join(&safe_stage);
+            let workspace_dir = group_root.join("workspace");
+            let stage_dir = match stage_name {
+                "" | "__cleanup__" => None,
+                _ => Some(group_root.join("stages").join(&safe_stage)),
+            };
             ResolvedStagePaths {
                 log_path,
-                workspace,
+                workspace_dir,
+                stage_dir,
             }
         } else {
             let log_path = Self::log_path(log_dir, job_group_id, stage_name, job_id);
-            let workspace = if !job_group_id.is_empty() {
+            let workspace_dir = if !job_group_id.is_empty() {
                 let safe_group = Self::sanitize_path_component(job_group_id);
                 PathBuf::from(work_dir).join(safe_group)
             } else {
@@ -386,7 +484,8 @@ impl StageRunner {
             };
             ResolvedStagePaths {
                 log_path,
-                workspace,
+                workspace_dir,
+                stage_dir: None,
             }
         }
     }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,17 +28,25 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
+    const status = error.response?.status;
+    const url: string = error.config?.url || '';
+    // A 401 from the login endpoint means "bad credentials" — let the caller
+    // (LoginPage) show the error. Only treat 401 on OTHER endpoints as an
+    // expired/invalid session that should log out and redirect. Also skip the
+    // hard redirect when already on /login so we don't reload over the toast.
+    const isAuthAttempt = url.includes('/auth/login');
+    if (status === 401 && !isAuthAttempt) {
       useAuthStore.getState().logout();
-      window.location.href = '/login';
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
       return Promise.reject(error);
     }
     const message = error.response?.data?.error
       || error.response?.statusText
       || error.message
       || 'An unexpected error occurred';
-    const status = error.response?.status;
-    error.userMessage = status >= 500
+    error.userMessage = status && status >= 500
       ? 'Server error. Please try again later.'
       : message;
     error.statusCode = status;

--- a/frontend/src/components/pipeline/PipelineExplorer.tsx
+++ b/frontend/src/components/pipeline/PipelineExplorer.tsx
@@ -2,31 +2,27 @@ import { useMemo, useState } from 'react';
 import { clsx } from 'clsx';
 import { useQuery } from '@tanstack/react-query';
 import apiClient from '../../api/client';
-import type { Job } from '../../types';
+import type { Job, JobGroup } from '../../types';
 import { StatusBadge } from '../ui/StatusBadge';
 import { LogViewer } from '../log/LogViewer';
 import { useLiveLog } from '../../hooks/useLiveLog';
 import { PipelineGraph } from './PipelineGraph';
 import {
-  buildPipeline,
+  buildPipelineModel,
   parseLogSections,
   type PipelineLeaf,
-  type PipelineNode,
+  type StepRef,
 } from '../../lib/pipeline';
 
 interface Props {
   jobs: Job[];
+  group: JobGroup;
   filesPurgedAt?: string | null;
   /** When set, a "Retry stage" button shows for the selected failed stage. */
   onRetryJob?: (job: Job) => void;
 }
 
-interface Selection {
-  jobId: string;
-  kind: PipelineLeaf['kind'];
-}
-
-// ── Right pane: output for the selected leaf ────────────────────────────────
+// ── Right pane: output for the selected job step ────────────────────────────
 
 function LeafOutput({
   job,
@@ -48,8 +44,6 @@ function LeafOutput({
     enabled: !isRunning && !!job.id && !isPurged,
   });
 
-  // While running we stream the full live log (slicing a growing stream is
-  // noisy); once complete we show just the selected section.
   const completedFull: string = logData?.data || '';
   const section = useMemo(
     () => (isRunning ? '' : parseLogSections(completedFull)[kind]),
@@ -67,60 +61,36 @@ function LeafOutput({
   );
 }
 
-// ── Right header: pre/cmd/post tabs for the selected node ────────────────────
-
-function StepTabs({
-  leaves,
-  activeKind,
-  onSelect,
-}: {
-  leaves: PipelineLeaf[];
-  activeKind: PipelineLeaf['kind'];
-  onSelect: (kind: PipelineLeaf['kind']) => void;
-}) {
-  return (
-    <div className="flex items-center gap-1">
-      {leaves.map((leaf) => (
-        <button
-          key={leaf.key}
-          onClick={() => onSelect(leaf.kind)}
-          className={clsx(
-            'px-2.5 py-1 text-xs rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent',
-            leaf.kind === activeKind
-              ? 'bg-accent-soft text-accent-text'
-              : 'text-muted hover:bg-surface-hover/50',
-          )}
-        >
-          {leaf.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 // ── Explorer ────────────────────────────────────────────────────────────────
 
-export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
-  const nodes = useMemo(() => buildPipeline(jobs), [jobs]);
+export function PipelineExplorer({ jobs, group, filesPurgedAt, onRetryJob }: Props) {
+  const model = useMemo(() => buildPipelineModel(jobs, group), [jobs, group]);
 
-  const initial = useMemo<Selection | null>(() => {
-    if (!nodes.length) return null;
-    const running = nodes.find((n) => n.state === 'running');
-    const target = running ?? nodes[nodes.length - 1];
+  const initial = useMemo<StepRef | null>(() => {
+    if (!model.stages.length) return null;
+    const running = model.stages.find((n) => n.state === 'running');
+    const target = running ?? model.stages[model.stages.length - 1];
     const cmd = target.leaves.find((l) => l.kind === 'cmd') ?? target.leaves[0];
-    return cmd ? { jobId: target.job.id, kind: cmd.kind } : null;
-  }, [nodes]);
+    return cmd
+      ? {
+          type: 'job',
+          key: cmd.key,
+          jobId: cmd.jobId,
+          kind: cmd.kind,
+          label: cmd.label,
+          state: cmd.state,
+          exitCode: cmd.exitCode,
+        }
+      : null;
+  }, [model]);
 
-  const [selection, setSelection] = useState<Selection | null>(initial);
+  const [selection, setSelection] = useState<StepRef | null>(initial);
   const active = selection ?? initial;
 
-  const activeNode: PipelineNode | null = active
-    ? nodes.find((n) => n.job.id === active.jobId) ?? null
-    : null;
-  const selectedJob = activeNode?.job ?? null;
-  const activeLeaf = activeNode?.leaves.find((l) => l.kind === active?.kind) ?? null;
+  const selectedJob =
+    active?.type === 'job' ? jobs.find((j) => j.id === active.jobId) ?? null : null;
 
-  if (!nodes.length) {
+  if (!model.stages.length && !model.globalPre.present && !model.globalPost.present) {
     return (
       <div className="bg-surface border border-border rounded-xl px-4 py-8 text-center text-disabled">
         No stages submitted yet
@@ -129,21 +99,14 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[minmax(240px,320px)_1fr] gap-3">
-      {/* Left: pipeline graph (Blue-Ocean style, parallel split/join) */}
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(260px,340px)_1fr] gap-3">
+      {/* Left: pipeline graph */}
       <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
         <div className="px-4 py-3 border-b border-border shrink-0">
           <h3 className="text-sm font-semibold text-secondary">Pipeline</h3>
         </div>
-        <div className="p-4 overflow-y-auto">
-          <PipelineGraph
-            nodes={nodes}
-            selectedJobId={selectedJob?.id}
-            onSelectNode={(node) => {
-              const cmd = node.leaves.find((l) => l.kind === 'cmd') ?? node.leaves[0];
-              if (cmd) setSelection({ jobId: node.job.id, kind: cmd.kind });
-            }}
-          />
+        <div className="p-3 overflow-y-auto">
+          <PipelineGraph model={model} selectedKey={active?.key} onSelect={setSelection} />
         </div>
       </div>
 
@@ -151,15 +114,8 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
       <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
         <div className="px-4 py-3 border-b border-border flex items-center gap-3 shrink-0 flex-wrap">
           <h3 className="text-sm font-semibold text-secondary truncate">
-            {selectedJob ? selectedJob.stage_name : 'Output'}
+            {active ? active.label : 'Output'}
           </h3>
-          {activeNode && active && (
-            <StepTabs
-              leaves={activeNode.leaves}
-              activeKind={active.kind}
-              onSelect={(kind) => setSelection({ jobId: activeNode.job.id, kind })}
-            />
-          )}
           {selectedJob?.state === 'failed' && onRetryJob && (
             <button
               onClick={() => onRetryJob(selectedJob)}
@@ -168,28 +124,32 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
               Retry stage
             </button>
           )}
-          {activeLeaf && (
+          {active && (
             <span className="ml-auto flex items-center gap-2 shrink-0">
-              {activeLeaf.exitCode !== null && (
+              {active.type === 'job' && active.exitCode !== null && (
                 <span
                   className={clsx(
                     'font-mono text-xs',
-                    activeLeaf.exitCode === 0 ? 'text-disabled' : 'text-danger',
+                    active.exitCode === 0 ? 'text-disabled' : 'text-danger',
                   )}
                 >
-                  exit {activeLeaf.exitCode}
+                  exit {active.exitCode}
                 </span>
               )}
-              <StatusBadge status={activeLeaf.state} />
+              <StatusBadge status={active.state} />
             </span>
           )}
         </div>
         <div className="flex-1 p-2 overflow-hidden">
-          {selectedJob && active ? (
+          {active?.type === 'job' && selectedJob ? (
             <LeafOutput job={selectedJob} kind={active.kind} filesPurgedAt={filesPurgedAt} />
+          ) : active?.type === 'info' ? (
+            <div className="h-full flex items-center justify-center text-center text-disabled text-sm px-6">
+              {active.message}
+            </div>
           ) : (
             <div className="h-full flex items-center justify-center text-disabled text-sm">
-              Select a stage on the left
+              Select a step on the left
             </div>
           )}
         </div>

--- a/frontend/src/components/pipeline/PipelineExplorer.tsx
+++ b/frontend/src/components/pipeline/PipelineExplorer.tsx
@@ -1,0 +1,235 @@
+import { useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { useQuery } from '@tanstack/react-query';
+import apiClient from '../../api/client';
+import type { Job } from '../../types';
+import { StatusBadge } from '../ui/StatusBadge';
+import { LogViewer } from '../log/LogViewer';
+import { useLiveLog } from '../../hooks/useLiveLog';
+import {
+  buildPipeline,
+  parseLogSections,
+  type PipelineLeaf,
+  type PipelineNode,
+} from '../../lib/pipeline';
+
+interface Props {
+  jobs: Job[];
+  filesPurgedAt?: string | null;
+  /** When set, a "Retry stage" button shows for the selected failed stage. */
+  onRetryJob?: (job: Job) => void;
+}
+
+interface Selection {
+  jobId: string;
+  leafKey: string;
+  kind: PipelineLeaf['kind'];
+}
+
+// ── Right pane: output for the selected leaf ────────────────────────────────
+
+function LeafOutput({
+  job,
+  kind,
+  filesPurgedAt,
+}: {
+  job: Job;
+  kind: PipelineLeaf['kind'];
+  filesPurgedAt?: string | null;
+}) {
+  const isRunning = job.state === 'running' || job.state === 'assigned';
+  const isPurged = !!filesPurgedAt;
+
+  const { chunks } = useLiveLog(job.id, isRunning && !isPurged);
+
+  const { data: logData } = useQuery({
+    queryKey: ['job-logs', job.id],
+    queryFn: () => apiClient.get(`/jobs/${job.id}/logs`).then((r) => r.data),
+    enabled: !isRunning && !!job.id && !isPurged,
+  });
+
+  // While running we stream the full live log (slicing a growing stream is
+  // noisy); once complete we show just the selected section.
+  const completedFull: string = logData?.data || '';
+  const section = useMemo(
+    () => (isRunning ? '' : parseLogSections(completedFull)[kind]),
+    [isRunning, completedFull, kind],
+  );
+
+  return (
+    <LogViewer
+      // Remount when the selected leaf changes so xterm shows fresh content.
+      key={`${job.id}:${kind}:${isRunning ? 'live' : 'done'}`}
+      content={isRunning ? undefined : (section || `(no ${kind} output)`)}
+      liveChunks={isRunning ? chunks : undefined}
+      filesPurgedAt={filesPurgedAt}
+      className="h-full"
+    />
+  );
+}
+
+// ── Left pane: accordion node + leaves ──────────────────────────────────────
+
+function LeafRow({
+  leaf,
+  selected,
+  onSelect,
+}: {
+  leaf: PipelineLeaf;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={clsx(
+        'w-full flex items-center justify-between gap-2 pl-9 pr-3 py-1.5 text-left text-xs rounded-md transition-colors',
+        'focus:outline-none focus:ring-2 focus:ring-accent',
+        selected ? 'bg-accent-soft text-accent-text' : 'hover:bg-surface-hover/50 text-secondary',
+      )}
+    >
+      <span className="font-mono truncate">{leaf.label}</span>
+      <StatusBadge status={leaf.state} />
+    </button>
+  );
+}
+
+function NodeRow({
+  node,
+  expanded,
+  onToggle,
+  selection,
+  onSelectLeaf,
+}: {
+  node: PipelineNode;
+  expanded: boolean;
+  onToggle: () => void;
+  selection: Selection | null;
+  onSelectLeaf: (leaf: PipelineLeaf) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-surface-2/30 overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface-hover/50 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+        aria-expanded={expanded}
+      >
+        <svg
+          className={clsx('w-3.5 h-3.5 text-disabled transition-transform shrink-0', expanded && 'rotate-90')}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        <span className="text-sm font-medium text-secondary truncate flex-1">{node.title}</span>
+        <StatusBadge status={node.state} />
+      </button>
+      {expanded && (
+        <div className="px-2 pb-2 pt-0.5 space-y-1">
+          {node.leaves.map((leaf) => (
+            <LeafRow
+              key={leaf.key}
+              leaf={leaf}
+              selected={selection?.leafKey === leaf.key}
+              onSelect={() => onSelectLeaf(leaf)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Explorer ────────────────────────────────────────────────────────────────
+
+export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
+  const nodes = useMemo(() => buildPipeline(jobs), [jobs]);
+
+  // Default selection: the command leaf of the running stage, else the last
+  // stage's command.
+  const initial = useMemo<Selection | null>(() => {
+    if (!nodes.length) return null;
+    const running = nodes.find((n) => n.state === 'running');
+    const target = running ?? nodes[nodes.length - 1];
+    const cmd = target.leaves.find((l) => l.kind === 'cmd') ?? target.leaves[0];
+    return cmd ? { jobId: target.job.id, leafKey: cmd.key, kind: cmd.kind } : null;
+  }, [nodes]);
+
+  const [selection, setSelection] = useState<Selection | null>(initial);
+  const active = selection ?? initial;
+
+  // Expand the node containing the active selection by default.
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const s = new Set<string>();
+    const owner = nodes.find((n) => n.leaves.some((l) => l.key === initial?.leafKey));
+    if (owner) s.add(owner.key);
+    return s;
+  });
+
+  const selectedJob = active ? jobs.find((j) => j.id === active.jobId) ?? null : null;
+
+  if (!nodes.length) {
+    return (
+      <div className="bg-surface border border-border rounded-xl px-4 py-8 text-center text-disabled">
+        No stages submitted yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(260px,340px)_1fr] gap-3">
+      {/* Left: pipeline tree */}
+      <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
+        <div className="px-4 py-3 border-b border-border shrink-0">
+          <h3 className="text-sm font-semibold text-secondary">Pipeline</h3>
+        </div>
+        <div className="p-2 space-y-2 overflow-y-auto">
+          {nodes.map((node) => (
+            <NodeRow
+              key={node.key}
+              node={node}
+              expanded={expanded.has(node.key)}
+              onToggle={() =>
+                setExpanded((prev) => {
+                  const next = new Set(prev);
+                  next.has(node.key) ? next.delete(node.key) : next.add(node.key);
+                  return next;
+                })
+              }
+              selection={active}
+              onSelectLeaf={(leaf) =>
+                setSelection({ jobId: node.job.id, leafKey: leaf.key, kind: leaf.kind })
+              }
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Right: output */}
+      <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
+        <div className="px-4 py-3 border-b border-border flex items-center gap-3 shrink-0">
+          <h3 className="text-sm font-semibold text-secondary truncate">
+            {selectedJob ? `${selectedJob.stage_name} · ${active?.kind}` : 'Output'}
+          </h3>
+          {selectedJob && <StatusBadge status={selectedJob.state} />}
+          {selectedJob?.state === 'failed' && onRetryJob && (
+            <button
+              onClick={() => onRetryJob(selectedJob)}
+              className="ml-auto px-3 py-1 text-xs bg-warning-soft text-warning border border-warning/30 rounded-lg hover:opacity-80 transition-colors focus:outline-none focus:ring-2 focus:ring-warning"
+            >
+              Retry stage
+            </button>
+          )}
+        </div>
+        <div className="flex-1 p-2 overflow-hidden">
+          {selectedJob && active ? (
+            <LeafOutput job={selectedJob} kind={active.kind} filesPurgedAt={filesPurgedAt} />
+          ) : (
+            <div className="h-full flex items-center justify-center text-disabled text-sm">
+              Select a step on the left
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pipeline/PipelineExplorer.tsx
+++ b/frontend/src/components/pipeline/PipelineExplorer.tsx
@@ -89,7 +89,19 @@ function LeafRow({
       )}
     >
       <span className="font-mono truncate">{leaf.label}</span>
-      <StatusBadge status={leaf.state} />
+      <span className="flex items-center gap-2 shrink-0">
+        {leaf.exitCode !== null && (
+          <span
+            className={clsx(
+              'font-mono text-[10px]',
+              leaf.exitCode === 0 ? 'text-disabled' : 'text-danger',
+            )}
+          >
+            exit {leaf.exitCode}
+          </span>
+        )}
+        <StatusBadge status={leaf.state} />
+      </span>
     </button>
   );
 }
@@ -166,6 +178,9 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
   });
 
   const selectedJob = active ? jobs.find((j) => j.id === active.jobId) ?? null : null;
+  const activeLeaf = active
+    ? nodes.flatMap((n) => n.leaves).find((l) => l.key === active.leafKey) ?? null
+    : null;
 
   if (!nodes.length) {
     return (
@@ -210,14 +225,29 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
           <h3 className="text-sm font-semibold text-secondary truncate">
             {selectedJob ? `${selectedJob.stage_name} · ${active?.kind}` : 'Output'}
           </h3>
-          {selectedJob && <StatusBadge status={selectedJob.state} />}
           {selectedJob?.state === 'failed' && onRetryJob && (
             <button
               onClick={() => onRetryJob(selectedJob)}
-              className="ml-auto px-3 py-1 text-xs bg-warning-soft text-warning border border-warning/30 rounded-lg hover:opacity-80 transition-colors focus:outline-none focus:ring-2 focus:ring-warning"
+              className="px-3 py-1 text-xs bg-warning-soft text-warning border border-warning/30 rounded-lg hover:opacity-80 transition-colors focus:outline-none focus:ring-2 focus:ring-warning"
             >
               Retry stage
             </button>
+          )}
+          {/* Selected step status + exit code, pinned to the right. */}
+          {activeLeaf && (
+            <span className="ml-auto flex items-center gap-2 shrink-0">
+              {activeLeaf.exitCode !== null && (
+                <span
+                  className={clsx(
+                    'font-mono text-xs',
+                    activeLeaf.exitCode === 0 ? 'text-disabled' : 'text-danger',
+                  )}
+                >
+                  exit {activeLeaf.exitCode}
+                </span>
+              )}
+              <StatusBadge status={activeLeaf.state} />
+            </span>
           )}
         </div>
         <div className="flex-1 p-2 overflow-hidden">

--- a/frontend/src/components/pipeline/PipelineExplorer.tsx
+++ b/frontend/src/components/pipeline/PipelineExplorer.tsx
@@ -6,6 +6,7 @@ import type { Job } from '../../types';
 import { StatusBadge } from '../ui/StatusBadge';
 import { LogViewer } from '../log/LogViewer';
 import { useLiveLog } from '../../hooks/useLiveLog';
+import { PipelineGraph } from './PipelineGraph';
 import {
   buildPipeline,
   parseLogSections,
@@ -22,7 +23,6 @@ interface Props {
 
 interface Selection {
   jobId: string;
-  leafKey: string;
   kind: PipelineLeaf['kind'];
 }
 
@@ -58,7 +58,6 @@ function LeafOutput({
 
   return (
     <LogViewer
-      // Remount when the selected leaf changes so xterm shows fresh content.
       key={`${job.id}:${kind}:${isRunning ? 'live' : 'done'}`}
       content={isRunning ? undefined : (section || `(no ${kind} output)`)}
       liveChunks={isRunning ? chunks : undefined}
@@ -68,85 +67,33 @@ function LeafOutput({
   );
 }
 
-// ── Left pane: accordion node + leaves ──────────────────────────────────────
+// ── Right header: pre/cmd/post tabs for the selected node ────────────────────
 
-function LeafRow({
-  leaf,
-  selected,
+function StepTabs({
+  leaves,
+  activeKind,
   onSelect,
 }: {
-  leaf: PipelineLeaf;
-  selected: boolean;
-  onSelect: () => void;
+  leaves: PipelineLeaf[];
+  activeKind: PipelineLeaf['kind'];
+  onSelect: (kind: PipelineLeaf['kind']) => void;
 }) {
   return (
-    <button
-      onClick={onSelect}
-      className={clsx(
-        'w-full flex items-center justify-between gap-2 pl-9 pr-3 py-1.5 text-left text-xs rounded-md transition-colors',
-        'focus:outline-none focus:ring-2 focus:ring-accent',
-        selected ? 'bg-accent-soft text-accent-text' : 'hover:bg-surface-hover/50 text-secondary',
-      )}
-    >
-      <span className="font-mono truncate">{leaf.label}</span>
-      <span className="flex items-center gap-2 shrink-0">
-        {leaf.exitCode !== null && (
-          <span
-            className={clsx(
-              'font-mono text-[10px]',
-              leaf.exitCode === 0 ? 'text-disabled' : 'text-danger',
-            )}
-          >
-            exit {leaf.exitCode}
-          </span>
-        )}
-        <StatusBadge status={leaf.state} />
-      </span>
-    </button>
-  );
-}
-
-function NodeRow({
-  node,
-  expanded,
-  onToggle,
-  selection,
-  onSelectLeaf,
-}: {
-  node: PipelineNode;
-  expanded: boolean;
-  onToggle: () => void;
-  selection: Selection | null;
-  onSelectLeaf: (leaf: PipelineLeaf) => void;
-}) {
-  return (
-    <div className="rounded-lg border border-border/60 bg-surface-2/30 overflow-hidden">
-      <button
-        onClick={onToggle}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface-hover/50 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
-        aria-expanded={expanded}
-      >
-        <svg
-          className={clsx('w-3.5 h-3.5 text-disabled transition-transform shrink-0', expanded && 'rotate-90')}
-          fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+    <div className="flex items-center gap-1">
+      {leaves.map((leaf) => (
+        <button
+          key={leaf.key}
+          onClick={() => onSelect(leaf.kind)}
+          className={clsx(
+            'px-2.5 py-1 text-xs rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent',
+            leaf.kind === activeKind
+              ? 'bg-accent-soft text-accent-text'
+              : 'text-muted hover:bg-surface-hover/50',
+          )}
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
-        <span className="text-sm font-medium text-secondary truncate flex-1">{node.title}</span>
-        <StatusBadge status={node.state} />
-      </button>
-      {expanded && (
-        <div className="px-2 pb-2 pt-0.5 space-y-1">
-          {node.leaves.map((leaf) => (
-            <LeafRow
-              key={leaf.key}
-              leaf={leaf}
-              selected={selection?.leafKey === leaf.key}
-              onSelect={() => onSelectLeaf(leaf)}
-            />
-          ))}
-        </div>
-      )}
+          {leaf.label}
+        </button>
+      ))}
     </div>
   );
 }
@@ -156,31 +103,22 @@ function NodeRow({
 export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
   const nodes = useMemo(() => buildPipeline(jobs), [jobs]);
 
-  // Default selection: the command leaf of the running stage, else the last
-  // stage's command.
   const initial = useMemo<Selection | null>(() => {
     if (!nodes.length) return null;
     const running = nodes.find((n) => n.state === 'running');
     const target = running ?? nodes[nodes.length - 1];
     const cmd = target.leaves.find((l) => l.kind === 'cmd') ?? target.leaves[0];
-    return cmd ? { jobId: target.job.id, leafKey: cmd.key, kind: cmd.kind } : null;
+    return cmd ? { jobId: target.job.id, kind: cmd.kind } : null;
   }, [nodes]);
 
   const [selection, setSelection] = useState<Selection | null>(initial);
   const active = selection ?? initial;
 
-  // Expand the node containing the active selection by default.
-  const [expanded, setExpanded] = useState<Set<string>>(() => {
-    const s = new Set<string>();
-    const owner = nodes.find((n) => n.leaves.some((l) => l.key === initial?.leafKey));
-    if (owner) s.add(owner.key);
-    return s;
-  });
-
-  const selectedJob = active ? jobs.find((j) => j.id === active.jobId) ?? null : null;
-  const activeLeaf = active
-    ? nodes.flatMap((n) => n.leaves).find((l) => l.key === active.leafKey) ?? null
+  const activeNode: PipelineNode | null = active
+    ? nodes.find((n) => n.job.id === active.jobId) ?? null
     : null;
+  const selectedJob = activeNode?.job ?? null;
+  const activeLeaf = activeNode?.leaves.find((l) => l.kind === active?.kind) ?? null;
 
   if (!nodes.length) {
     return (
@@ -191,40 +129,37 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[minmax(260px,340px)_1fr] gap-3">
-      {/* Left: pipeline tree */}
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(240px,320px)_1fr] gap-3">
+      {/* Left: pipeline graph (Blue-Ocean style, parallel split/join) */}
       <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
         <div className="px-4 py-3 border-b border-border shrink-0">
           <h3 className="text-sm font-semibold text-secondary">Pipeline</h3>
         </div>
-        <div className="p-2 space-y-2 overflow-y-auto">
-          {nodes.map((node) => (
-            <NodeRow
-              key={node.key}
-              node={node}
-              expanded={expanded.has(node.key)}
-              onToggle={() =>
-                setExpanded((prev) => {
-                  const next = new Set(prev);
-                  next.has(node.key) ? next.delete(node.key) : next.add(node.key);
-                  return next;
-                })
-              }
-              selection={active}
-              onSelectLeaf={(leaf) =>
-                setSelection({ jobId: node.job.id, leafKey: leaf.key, kind: leaf.kind })
-              }
-            />
-          ))}
+        <div className="p-4 overflow-y-auto">
+          <PipelineGraph
+            nodes={nodes}
+            selectedJobId={selectedJob?.id}
+            onSelectNode={(node) => {
+              const cmd = node.leaves.find((l) => l.kind === 'cmd') ?? node.leaves[0];
+              if (cmd) setSelection({ jobId: node.job.id, kind: cmd.kind });
+            }}
+          />
         </div>
       </div>
 
       {/* Right: output */}
       <div className="bg-surface border border-border rounded-xl flex flex-col min-h-[28rem] max-h-[36rem]">
-        <div className="px-4 py-3 border-b border-border flex items-center gap-3 shrink-0">
+        <div className="px-4 py-3 border-b border-border flex items-center gap-3 shrink-0 flex-wrap">
           <h3 className="text-sm font-semibold text-secondary truncate">
-            {selectedJob ? `${selectedJob.stage_name} · ${active?.kind}` : 'Output'}
+            {selectedJob ? selectedJob.stage_name : 'Output'}
           </h3>
+          {activeNode && active && (
+            <StepTabs
+              leaves={activeNode.leaves}
+              activeKind={active.kind}
+              onSelect={(kind) => setSelection({ jobId: activeNode.job.id, kind })}
+            />
+          )}
           {selectedJob?.state === 'failed' && onRetryJob && (
             <button
               onClick={() => onRetryJob(selectedJob)}
@@ -233,7 +168,6 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
               Retry stage
             </button>
           )}
-          {/* Selected step status + exit code, pinned to the right. */}
           {activeLeaf && (
             <span className="ml-auto flex items-center gap-2 shrink-0">
               {activeLeaf.exitCode !== null && (
@@ -255,7 +189,7 @@ export function PipelineExplorer({ jobs, filesPurgedAt, onRetryJob }: Props) {
             <LeafOutput job={selectedJob} kind={active.kind} filesPurgedAt={filesPurgedAt} />
           ) : (
             <div className="h-full flex items-center justify-center text-disabled text-sm">
-              Select a step on the left
+              Select a stage on the left
             </div>
           )}
         </div>

--- a/frontend/src/components/pipeline/PipelineGraph.tsx
+++ b/frontend/src/components/pipeline/PipelineGraph.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import { clsx } from 'clsx';
+import { StatusBadge } from '../ui/StatusBadge';
+import { clusterRows, type PipelineNode } from '../../lib/pipeline';
+
+interface Props {
+  nodes: PipelineNode[];
+  selectedJobId?: string;
+  onSelectNode: (node: PipelineNode) => void;
+}
+
+/** Horizontal centre (0..1) of lane `i` in a row of `count` lanes. */
+function laneX(i: number, count: number): number {
+  return (i + 0.5) / count;
+}
+
+/**
+ * Connector band between a row of `prev` lanes (top) and `cur` lanes
+ * (bottom). Lines fan from each top centre into a shared midpoint, then out
+ * to each bottom centre — reads as a join-then-split (git-graph style).
+ */
+function Connector({ prev, cur }: { prev: number; cur: number }) {
+  const lines: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  const mx = 50;
+  for (let i = 0; i < prev; i++) lines.push({ x1: laneX(i, prev) * 100, y1: 0, x2: mx, y2: 50 });
+  for (let j = 0; j < cur; j++) lines.push({ x1: mx, y1: 50, x2: laneX(j, cur) * 100, y2: 100 });
+  return (
+    <svg
+      className="w-full h-6 text-border-strong"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      {lines.map((l, i) => (
+        <line key={i} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+      ))}
+    </svg>
+  );
+}
+
+function StageNode({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: PipelineNode;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={clsx(
+        'flex flex-col items-center gap-1 px-3 py-2 rounded-lg border transition-colors min-w-[7rem] max-w-[12rem]',
+        'focus:outline-none focus:ring-2 focus:ring-accent',
+        selected
+          ? 'bg-accent-soft border-accent/50'
+          : 'bg-surface-2/40 border-border/60 hover:bg-surface-hover/50',
+      )}
+      title={node.stageName}
+    >
+      <span className="text-xs font-medium text-secondary font-mono truncate w-full text-center">
+        {node.stageName}
+      </span>
+      <StatusBadge status={node.state} />
+    </button>
+  );
+}
+
+export function PipelineGraph({ nodes, selectedJobId, onSelectNode }: Props) {
+  const rows = useMemo(() => clusterRows(nodes), [nodes]);
+
+  return (
+    <div className="flex flex-col items-stretch">
+      {rows.map((row, ri) => (
+        <div key={ri}>
+          {ri > 0 && <Connector prev={rows[ri - 1].length} cur={row.length} />}
+          <div className="flex items-stretch justify-center gap-3">
+            {row.map((node) => (
+              <StageNode
+                key={node.key}
+                node={node}
+                selected={node.job.id === selectedJobId}
+                onSelect={() => onSelectNode(node)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/pipeline/PipelineGraph.tsx
+++ b/frontend/src/components/pipeline/PipelineGraph.tsx
@@ -1,12 +1,18 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { clsx } from 'clsx';
 import { StatusBadge } from '../ui/StatusBadge';
-import { clusterRows, type PipelineNode } from '../../lib/pipeline';
+import {
+  clusterRows,
+  leafToStep,
+  type PipelineModel,
+  type PipelineNode,
+  type StepRef,
+} from '../../lib/pipeline';
 
 interface Props {
-  nodes: PipelineNode[];
-  selectedJobId?: string;
-  onSelectNode: (node: PipelineNode) => void;
+  model: PipelineModel;
+  selectedKey?: string;
+  onSelect: (step: StepRef) => void;
 }
 
 /** Horizontal centre (0..1) of lane `i` in a row of `count` lanes. */
@@ -14,77 +20,163 @@ function laneX(i: number, count: number): number {
   return (i + 0.5) / count;
 }
 
-/**
- * Connector band between a row of `prev` lanes (top) and `cur` lanes
- * (bottom). Lines fan from each top centre into a shared midpoint, then out
- * to each bottom centre — reads as a join-then-split (git-graph style).
- */
+/** Split/join connector band between `prev` lanes (top) and `cur` (bottom). */
 function Connector({ prev, cur }: { prev: number; cur: number }) {
-  const lines: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  const lines: { x1: number; x2: number }[] = [];
   const mx = 50;
-  for (let i = 0; i < prev; i++) lines.push({ x1: laneX(i, prev) * 100, y1: 0, x2: mx, y2: 50 });
-  for (let j = 0; j < cur; j++) lines.push({ x1: mx, y1: 50, x2: laneX(j, cur) * 100, y2: 100 });
+  for (let i = 0; i < prev; i++) lines.push({ x1: laneX(i, prev) * 100, x2: mx });
+  const top = lines.map((l, i) => ({ ...l, y1: 0, y2: 50, k: `t${i}` }));
+  const bottom: { x1: number; y1: number; x2: number; y2: number; k: string }[] = [];
+  for (let j = 0; j < cur; j++) bottom.push({ x1: mx, y1: 50, x2: laneX(j, cur) * 100, y2: 100, k: `b${j}` });
+  const all = [...top.map((l) => ({ x1: l.x1, y1: l.y1, x2: l.x2, y2: l.y2, k: l.k })), ...bottom];
   return (
-    <svg
-      className="w-full h-6 text-border-strong"
-      viewBox="0 0 100 100"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      {lines.map((l, i) => (
-        <line key={i} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+    <svg className="w-full h-5 text-border-strong" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+      {all.map((l) => (
+        <line key={l.k} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
       ))}
     </svg>
   );
 }
 
-function StageNode({
-  node,
-  selected,
-  onSelect,
-}: {
-  node: PipelineNode;
-  selected: boolean;
-  onSelect: () => void;
-}) {
+function StepChip({ step, selected, onClick }: { step: StepRef; selected: boolean; onClick: () => void }) {
   return (
     <button
-      onClick={onSelect}
+      onClick={onClick}
       className={clsx(
-        'flex flex-col items-center gap-1 px-3 py-2 rounded-lg border transition-colors min-w-[7rem] max-w-[12rem]',
+        'w-full flex items-center justify-between gap-2 pl-3 pr-2 py-1 text-left text-xs rounded-md transition-colors',
         'focus:outline-none focus:ring-2 focus:ring-accent',
-        selected
-          ? 'bg-accent-soft border-accent/50'
-          : 'bg-surface-2/40 border-border/60 hover:bg-surface-hover/50',
+        selected ? 'bg-accent-soft text-accent-text' : 'hover:bg-surface-hover/50 text-secondary',
       )}
-      title={node.stageName}
     >
-      <span className="text-xs font-medium text-secondary font-mono truncate w-full text-center">
-        {node.stageName}
+      <span className="font-mono truncate">{step.label}</span>
+      <span className="flex items-center gap-1.5 shrink-0">
+        {step.type === 'job' && step.exitCode !== null && (
+          <span className={clsx('font-mono text-[10px]', step.exitCode === 0 ? 'text-disabled' : 'text-danger')}>
+            {step.exitCode}
+          </span>
+        )}
+        <StatusBadge status={step.state} />
       </span>
-      <StatusBadge status={node.state} />
     </button>
   );
 }
 
-export function PipelineGraph({ nodes, selectedJobId, onSelectNode }: Props) {
-  const rows = useMemo(() => clusterRows(nodes), [nodes]);
+function ExpandableNode({
+  title,
+  state,
+  expanded,
+  onToggle,
+  children,
+}: {
+  title: string;
+  state: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="w-full rounded-lg border border-border/60 bg-surface-2/40 overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-surface-hover/50 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+        aria-expanded={expanded}
+      >
+        <svg
+          className={clsx('w-3.5 h-3.5 text-disabled transition-transform shrink-0', expanded && 'rotate-90')}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        <span className="text-xs font-medium text-secondary font-mono truncate flex-1">{title}</span>
+        <StatusBadge status={state} />
+      </button>
+      {expanded && <div className="px-1.5 pb-1.5 pt-0.5 space-y-1">{children}</div>}
+    </div>
+  );
+}
+
+type RailRow =
+  | { kind: 'global-pre' }
+  | { kind: 'global-post' }
+  | { kind: 'stages'; lanes: PipelineNode[] };
+
+export function PipelineGraph({ model, selectedKey, onSelect }: Props) {
+  const rows = useMemo<RailRow[]>(() => {
+    const out: RailRow[] = [];
+    if (model.globalPre.present) out.push({ kind: 'global-pre' });
+    for (const lanes of clusterRows(model.stages)) out.push({ kind: 'stages', lanes });
+    if (model.globalPost.present) out.push({ kind: 'global-post' });
+    return out;
+  }, [model]);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
+  const laneCount = (r: RailRow) => (r.kind === 'stages' ? r.lanes.length : 1);
 
   return (
-    <div className="flex flex-col items-stretch">
+    <div className="flex flex-col items-start w-full">
       {rows.map((row, ri) => (
-        <div key={ri}>
-          {ri > 0 && <Connector prev={rows[ri - 1].length} cur={row.length} />}
-          <div className="flex items-stretch justify-center gap-3">
-            {row.map((node) => (
-              <StageNode
-                key={node.key}
-                node={node}
-                selected={node.job.id === selectedJobId}
-                onSelect={() => onSelectNode(node)}
-              />
-            ))}
-          </div>
+        <div key={ri} className="w-full">
+          {ri > 0 && <Connector prev={laneCount(rows[ri - 1])} cur={laneCount(row)} />}
+
+          {row.kind === 'global-pre' && (
+            <ExpandableNode
+              title="Global pre-script"
+              state={model.globalPre.steps[0]?.state ?? 'unknown'}
+              expanded={expanded.has('global-pre')}
+              onToggle={() => toggle('global-pre')}
+            >
+              {model.globalPre.steps.map((s) => (
+                <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
+              ))}
+            </ExpandableNode>
+          )}
+
+          {row.kind === 'global-post' && (
+            <ExpandableNode
+              title="Global post-script"
+              state={model.globalPost.steps[0]?.state ?? 'unknown'}
+              expanded={expanded.has('global-post')}
+              onToggle={() => toggle('global-post')}
+            >
+              {model.globalPost.steps.map((s) => (
+                <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
+              ))}
+            </ExpandableNode>
+          )}
+
+          {row.kind === 'stages' && (
+            <div className="flex items-start justify-start gap-3">
+              {row.lanes.map((node) => {
+                const steps = node.leaves.map(leafToStep);
+                return (
+                  <div key={node.key} className="flex-1 min-w-[8rem] max-w-[16rem]">
+                    <ExpandableNode
+                      title={node.stageName}
+                      state={node.state}
+                      expanded={expanded.has(node.key)}
+                      onToggle={() => {
+                        toggle(node.key);
+                        // selecting the stage also surfaces its command output
+                        const cmd = steps.find((s) => s.type === 'job' && s.kind === 'cmd');
+                        if (cmd && !expanded.has(node.key)) onSelect(cmd);
+                      }}
+                    >
+                      {steps.map((s) => (
+                        <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
+                      ))}
+                    </ExpandableNode>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/frontend/src/components/pipeline/PipelineGraph.tsx
+++ b/frontend/src/components/pipeline/PipelineGraph.tsx
@@ -5,7 +5,6 @@ import {
   clusterRows,
   leafToStep,
   type PipelineModel,
-  type PipelineNode,
   type StepRef,
 } from '../../lib/pipeline';
 
@@ -15,25 +14,67 @@ interface Props {
   onSelect: (step: StepRef) => void;
 }
 
-/** Horizontal centre (0..1) of lane `i` in a row of `count` lanes. */
-function laneX(i: number, count: number): number {
-  return (i + 0.5) / count;
+const LANE_W = 22; // px per lane in the graph gutter
+const DOT_CY = 18; // px — vertical centre of a node's dot (aligns with header)
+
+interface RailItem {
+  key: string;
+  title: string;
+  state: string;
+  /** Lane (column) this node sits on; 0 = main spine. */
+  lane: number;
+  steps: StepRef[];
 }
 
-/** Split/join connector band between `prev` lanes (top) and `cur` (bottom). */
-function Connector({ prev, cur }: { prev: number; cur: number }) {
-  const lines: { x1: number; x2: number }[] = [];
-  const mx = 50;
-  for (let i = 0; i < prev; i++) lines.push({ x1: laneX(i, prev) * 100, x2: mx });
-  const top = lines.map((l, i) => ({ ...l, y1: 0, y2: 50, k: `t${i}` }));
-  const bottom: { x1: number; y1: number; x2: number; y2: number; k: string }[] = [];
-  for (let j = 0; j < cur; j++) bottom.push({ x1: mx, y1: 50, x2: laneX(j, cur) * 100, y2: 100, k: `b${j}` });
-  const all = [...top.map((l) => ({ x1: l.x1, y1: l.y1, x2: l.x2, y2: l.y2, k: l.k })), ...bottom];
+/** dot/branch colour by node state. */
+function dotColor(state: string): string {
+  switch (state) {
+    case 'success': return 'var(--color-success)';
+    case 'failed': return 'var(--color-danger)';
+    case 'cancelled':
+    case 'expired': return 'var(--color-warning)';
+    case 'running':
+    case 'assigned': return 'var(--color-accent)';
+    default: return 'var(--color-text-muted)';
+  }
+}
+
+/** Per-row graph gutter: the continuous spine (lane 0), an elbow to this
+ *  node's lane when it branches, and the node's dot. The SVG stretches to the
+ *  row height so the spine stays connected even when a row is expanded. */
+function Gutter({
+  lane,
+  maxLane,
+  isFirst,
+  isLast,
+  color,
+}: {
+  lane: number;
+  maxLane: number;
+  isFirst: boolean;
+  isLast: boolean;
+  color: string;
+}) {
+  const width = (maxLane + 1) * LANE_W;
+  const x0 = LANE_W / 2; // spine x
+  const xL = lane * LANE_W + LANE_W / 2; // this node's x
   return (
-    <svg className="w-full h-5 text-border-strong" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      {all.map((l) => (
-        <line key={l.k} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
-      ))}
+    <svg width={width} className="shrink-0 h-full text-border-strong" preserveAspectRatio="none" aria-hidden="true">
+      {/* main spine (lane 0) */}
+      <line
+        x1={x0}
+        y1={isFirst ? DOT_CY : 0}
+        x2={x0}
+        y2={isLast && lane === 0 ? DOT_CY : '100%'}
+        stroke="currentColor"
+        strokeWidth={2}
+      />
+      {/* elbow from the spine out to a branch lane */}
+      {lane > 0 && (
+        <line x1={x0} y1={DOT_CY} x2={xL} y2={DOT_CY} stroke="currentColor" strokeWidth={2} />
+      )}
+      {/* node dot */}
+      <circle cx={xL} cy={DOT_CY} r={4.5} fill={color} stroke="var(--color-surface)" strokeWidth={2} />
     </svg>
   );
 }
@@ -61,53 +102,42 @@ function StepChip({ step, selected, onClick }: { step: StepRef; selected: boolea
   );
 }
 
-function ExpandableNode({
-  title,
-  state,
-  expanded,
-  onToggle,
-  children,
-}: {
-  title: string;
-  state: string;
-  expanded: boolean;
-  onToggle: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="w-full rounded-lg border border-border/60 bg-surface-2/40 overflow-hidden">
-      <button
-        onClick={onToggle}
-        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-surface-hover/50 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
-        aria-expanded={expanded}
-      >
-        <svg
-          className={clsx('w-3.5 h-3.5 text-disabled transition-transform shrink-0', expanded && 'rotate-90')}
-          fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
-        <span className="text-xs font-medium text-secondary font-mono truncate flex-1">{title}</span>
-        <StatusBadge status={state} />
-      </button>
-      {expanded && <div className="px-1.5 pb-1.5 pt-0.5 space-y-1">{children}</div>}
-    </div>
-  );
-}
-
-type RailRow =
-  | { kind: 'global-pre' }
-  | { kind: 'global-post' }
-  | { kind: 'stages'; lanes: PipelineNode[] };
-
 export function PipelineGraph({ model, selectedKey, onSelect }: Props) {
-  const rows = useMemo<RailRow[]>(() => {
-    const out: RailRow[] = [];
-    if (model.globalPre.present) out.push({ kind: 'global-pre' });
-    for (const lanes of clusterRows(model.stages)) out.push({ kind: 'stages', lanes });
-    if (model.globalPost.present) out.push({ kind: 'global-post' });
+  const items = useMemo<RailItem[]>(() => {
+    const out: RailItem[] = [];
+    if (model.globalPre.present) {
+      out.push({
+        key: 'global-pre',
+        title: 'Global pre-script',
+        state: model.globalPre.steps[0]?.state ?? 'unknown',
+        lane: 0,
+        steps: model.globalPre.steps,
+      });
+    }
+    for (const row of clusterRows(model.stages)) {
+      row.forEach((node, i) => {
+        out.push({
+          key: node.key,
+          title: node.stageName,
+          state: node.state,
+          lane: i, // node 0 stays on the spine; siblings branch off
+          steps: node.leaves.map(leafToStep),
+        });
+      });
+    }
+    if (model.globalPost.present) {
+      out.push({
+        key: 'global-post',
+        title: 'Global post-script',
+        state: model.globalPost.steps[0]?.state ?? 'unknown',
+        lane: 0,
+        steps: model.globalPost.steps,
+      });
+    }
     return out;
   }, [model]);
+
+  const maxLane = useMemo(() => items.reduce((m, it) => Math.max(m, it.lane), 0), [items]);
 
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggle = (key: string) =>
@@ -117,68 +147,48 @@ export function PipelineGraph({ model, selectedKey, onSelect }: Props) {
       return next;
     });
 
-  const laneCount = (r: RailRow) => (r.kind === 'stages' ? r.lanes.length : 1);
-
   return (
-    <div className="flex flex-col items-start w-full">
-      {rows.map((row, ri) => (
-        <div key={ri} className="w-full">
-          {ri > 0 && <Connector prev={laneCount(rows[ri - 1])} cur={laneCount(row)} />}
-
-          {row.kind === 'global-pre' && (
-            <ExpandableNode
-              title="Global pre-script"
-              state={model.globalPre.steps[0]?.state ?? 'unknown'}
-              expanded={expanded.has('global-pre')}
-              onToggle={() => toggle('global-pre')}
-            >
-              {model.globalPre.steps.map((s) => (
-                <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
-              ))}
-            </ExpandableNode>
-          )}
-
-          {row.kind === 'global-post' && (
-            <ExpandableNode
-              title="Global post-script"
-              state={model.globalPost.steps[0]?.state ?? 'unknown'}
-              expanded={expanded.has('global-post')}
-              onToggle={() => toggle('global-post')}
-            >
-              {model.globalPost.steps.map((s) => (
-                <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
-              ))}
-            </ExpandableNode>
-          )}
-
-          {row.kind === 'stages' && (
-            <div className="flex items-start justify-start gap-3">
-              {row.lanes.map((node) => {
-                const steps = node.leaves.map(leafToStep);
-                return (
-                  <div key={node.key} className="flex-1 min-w-[8rem] max-w-[16rem]">
-                    <ExpandableNode
-                      title={node.stageName}
-                      state={node.state}
-                      expanded={expanded.has(node.key)}
-                      onToggle={() => {
-                        toggle(node.key);
-                        // selecting the stage also surfaces its command output
-                        const cmd = steps.find((s) => s.type === 'job' && s.kind === 'cmd');
-                        if (cmd && !expanded.has(node.key)) onSelect(cmd);
-                      }}
-                    >
-                      {steps.map((s) => (
-                        <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
-                      ))}
-                    </ExpandableNode>
-                  </div>
-                );
-              })}
+    <div className="flex flex-col">
+      {items.map((it, i) => {
+        const isOpen = expanded.has(it.key);
+        return (
+          <div key={it.key} className="flex items-stretch">
+            <Gutter
+              lane={it.lane}
+              maxLane={maxLane}
+              isFirst={i === 0}
+              isLast={i === items.length - 1}
+              color={dotColor(it.state)}
+            />
+            <div className="flex-1 min-w-0 pb-1">
+              {/* node header: caret + name + status */}
+              <button
+                onClick={() => toggle(it.key)}
+                className="w-full flex items-center gap-2 pr-1 text-left hover:bg-surface-hover/40 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+                style={{ minHeight: DOT_CY * 2 }}
+                aria-expanded={isOpen}
+              >
+                <svg
+                  className={clsx('w-3 h-3 text-disabled transition-transform shrink-0', isOpen && 'rotate-90')}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+                <span className="text-xs font-medium text-secondary font-mono truncate flex-1">{it.title}</span>
+                <StatusBadge status={it.state} />
+              </button>
+              {/* expanded sub-steps as a small branch off the node */}
+              {isOpen && it.steps.length > 0 && (
+                <div className="ml-3 mt-0.5 mb-1 pl-2 border-l border-border/60 space-y-0.5">
+                  {it.steps.map((s) => (
+                    <StepChip key={s.key} step={s} selected={selectedKey === s.key} onClick={() => onSelect(s)} />
+                  ))}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      ))}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/lib/pipeline.ts
+++ b/frontend/src/lib/pipeline.ts
@@ -133,6 +133,48 @@ export function buildPipeline(jobs: Job[]): PipelineNode[] {
   return nodes;
 }
 
+// ── Parallelism inference (for the Blue-Ocean-style graph) ──────────────────
+//
+// chola doesn't ship the stage DAG in the build-detail payload, so we infer
+// concurrency from execution windows: stages whose [start, end] intervals
+// overlap ran in parallel and share a "row" (drawn as side-by-side lanes);
+// a stage that starts after everything in the current row has finished
+// begins a new sequential row. Each row is one split/join band in the graph.
+
+function startMs(node: PipelineNode): number {
+  const s = node.job.started_at ?? node.job.created_at;
+  return s ? new Date(s).getTime() : 0;
+}
+
+function endMs(node: PipelineNode): number {
+  // Still-running stages extend to "now" so they overlap anything after them.
+  return node.job.completed_at ? new Date(node.job.completed_at).getTime() : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Group pipeline nodes into sequential rows of parallel lanes. Row order is
+ * by start time; within a row, lanes are stages that overlapped in time.
+ */
+export function clusterRows(nodes: PipelineNode[]): PipelineNode[][] {
+  const sorted = [...nodes].sort((a, b) => startMs(a) - startMs(b));
+  const rows: PipelineNode[][] = [];
+  let row: PipelineNode[] = [];
+  let rowEnd = -Infinity;
+
+  for (const node of sorted) {
+    if (row.length === 0 || startMs(node) < rowEnd) {
+      row.push(node);
+      rowEnd = Math.max(rowEnd, endMs(node));
+    } else {
+      rows.push(row);
+      row = [node];
+      rowEnd = endMs(node);
+    }
+  }
+  if (row.length) rows.push(row);
+  return rows;
+}
+
 export interface LogSections {
   pre: string;
   cmd: string;

--- a/frontend/src/lib/pipeline.ts
+++ b/frontend/src/lib/pipeline.ts
@@ -1,0 +1,165 @@
+// Pipeline model + log-section parsing for the build detail view.
+//
+// A build's jobs each carry a pre_script, command, and post_script that all
+// write into ONE stage log, separated by `[PRE]` / `[CMD]` / `[POST]` line
+// markers (emitted by the worker's stage_runner). The controller's global
+// post-script runs as a synthetic `__cleanup__` job.
+//
+// This module turns the flat `Job[]` into an ordered, expandable tree:
+//   Stage 1 <name>   ▸  [pre]  [cmd]  [post]
+//   Stage 2 <name>   ▸  [pre]  [cmd]  [post]
+//   Global post      ▸  [cmd]
+// and splits a stage log string into its pre/cmd/post sections so the right
+// pane can show just the selected leaf's output.
+
+import type { Job, JobState } from '../types';
+
+export type PipelineLeafKind = 'pre' | 'cmd' | 'post';
+
+export interface PipelineLeaf {
+  /** Stable id used for selection (`${jobId}:${kind}`). */
+  key: string;
+  kind: PipelineLeafKind;
+  /** Short label: "Pre-script", the stage/command name, or "Post-script". */
+  label: string;
+  /** Job whose log holds this leaf's output. */
+  jobId: string;
+  /** Derived status for just this sub-step. */
+  state: JobState;
+  exitCode: number | null;
+}
+
+export type PipelineNodeKind = 'stage' | 'global-post';
+
+export interface PipelineNode {
+  key: string;
+  /** Display title, e.g. "Stage 1 · vira-ci" or "Global post-script". */
+  title: string;
+  kind: PipelineNodeKind;
+  stageName: string;
+  job: Job;
+  /** Roll-up status for the whole node (the command's state). */
+  state: JobState;
+  leaves: PipelineLeaf[];
+}
+
+const CLEANUP_MARKER = '__cleanup__';
+
+/** Map a phase exit code to a JobState, given the parent job's lifecycle. */
+function leafStateFromExit(exitCode: number | null, parent: Job): JobState {
+  // Phase hasn't reported yet → inherit the parent's running/pending state.
+  if (exitCode === null || exitCode === undefined) {
+    if (parent.state === 'running' || parent.state === 'assigned') return 'running';
+    if (parent.state === 'queued') return 'queued';
+    // Parent terminal but this phase never recorded a code → unknown.
+    return parent.state === 'cancelled' ? 'cancelled' : 'unknown';
+  }
+  return exitCode === 0 ? 'success' : 'failed';
+}
+
+/** Build the ordered pipeline tree from a group's jobs. */
+export function buildPipeline(jobs: Job[]): PipelineNode[] {
+  const sorted = [...jobs].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+
+  const nodes: PipelineNode[] = [];
+  let stageIndex = 0;
+
+  for (const job of sorted) {
+    const isCleanup = job.stage_name.includes(CLEANUP_MARKER);
+
+    const leaves: PipelineLeaf[] = [];
+    if (!isCleanup && job.pre_script && job.pre_script.trim()) {
+      leaves.push({
+        key: `${job.id}:pre`,
+        kind: 'pre',
+        label: 'Pre-script',
+        jobId: job.id,
+        state: leafStateFromExit(job.pre_exit_code, job),
+        exitCode: job.pre_exit_code,
+      });
+    }
+    // The command leaf always exists.
+    leaves.push({
+      key: `${job.id}:cmd`,
+      kind: 'cmd',
+      label: isCleanup ? 'Cleanup script' : job.stage_name,
+      jobId: job.id,
+      state: job.state,
+      exitCode: job.exit_code,
+    });
+    if (!isCleanup && job.post_script && job.post_script.trim()) {
+      leaves.push({
+        key: `${job.id}:post`,
+        kind: 'post',
+        label: 'Post-script',
+        jobId: job.id,
+        state: leafStateFromExit(job.post_exit_code, job),
+        exitCode: job.post_exit_code,
+      });
+    }
+
+    if (isCleanup) {
+      nodes.push({
+        key: job.id,
+        title: 'Global post-script',
+        kind: 'global-post',
+        stageName: job.stage_name,
+        job,
+        state: job.state,
+        leaves,
+      });
+    } else {
+      stageIndex += 1;
+      nodes.push({
+        key: job.id,
+        title: `Stage ${stageIndex} · ${job.stage_name}`,
+        kind: 'stage',
+        stageName: job.stage_name,
+        job,
+        state: job.state,
+        leaves,
+      });
+    }
+  }
+
+  return nodes;
+}
+
+export interface LogSections {
+  pre: string;
+  cmd: string;
+  post: string;
+}
+
+/**
+ * Split a stage log into pre/cmd/post sections using the worker's
+ * `[PRE]` / `[CMD]` / `[POST]` line markers. `[LOCK]` and any other lines
+ * stay with whichever section is currently open. Lines before the first
+ * marker default to `pre` (workspace setup runs under the pre phase).
+ */
+export function parseLogSections(log: string): LogSections {
+  const out: LogSections = { pre: '', cmd: '', post: '' };
+  if (!log) return out;
+
+  const buf: Record<PipelineLeafKind, string[]> = { pre: [], cmd: [], post: [] };
+  let current: PipelineLeafKind = 'pre';
+
+  for (const line of log.split('\n')) {
+    if (line.startsWith('[PRE]')) current = 'pre';
+    else if (line.startsWith('[CMD]')) current = 'cmd';
+    else if (line.startsWith('[POST]')) current = 'post';
+    buf[current].push(line);
+  }
+
+  out.pre = buf.pre.join('\n');
+  out.cmd = buf.cmd.join('\n');
+  out.post = buf.post.join('\n');
+  return out;
+}
+
+/** Pull just one leaf's slice out of a full stage log. */
+export function sectionForLeaf(log: string, kind: PipelineLeafKind): string {
+  return parseLogSections(log)[kind];
+}

--- a/frontend/src/lib/pipeline.ts
+++ b/frontend/src/lib/pipeline.ts
@@ -69,8 +69,14 @@ export function buildPipeline(jobs: Job[]): PipelineNode[] {
   for (const job of sorted) {
     const isCleanup = job.stage_name.includes(CLEANUP_MARKER);
 
+    // A pre/post leaf exists if the script body is present OR the phase
+    // actually ran (exit code recorded) — the latter keeps leaves visible
+    // even when the API doesn't ship the script bodies.
+    const hasPre = !!(job.pre_script && job.pre_script.trim()) || job.pre_exit_code != null;
+    const hasPost = !!(job.post_script && job.post_script.trim()) || job.post_exit_code != null;
+
     const leaves: PipelineLeaf[] = [];
-    if (!isCleanup && job.pre_script && job.pre_script.trim()) {
+    if (!isCleanup && hasPre) {
       leaves.push({
         key: `${job.id}:pre`,
         kind: 'pre',
@@ -89,7 +95,7 @@ export function buildPipeline(jobs: Job[]): PipelineNode[] {
       state: job.state,
       exitCode: job.exit_code,
     });
-    if (!isCleanup && job.post_script && job.post_script.trim()) {
+    if (!isCleanup && hasPost) {
       leaves.push({
         key: `${job.id}:post`,
         kind: 'post',

--- a/frontend/src/lib/pipeline.ts
+++ b/frontend/src/lib/pipeline.ts
@@ -12,7 +12,7 @@
 // and splits a stage log string into its pre/cmd/post sections so the right
 // pane can show just the selected leaf's output.
 
-import type { Job, JobState } from '../types';
+import type { Job, JobState, JobGroup } from '../types';
 
 export type PipelineLeafKind = 'pre' | 'cmd' | 'post';
 
@@ -210,4 +210,127 @@ export function parseLogSections(log: string): LogSections {
 /** Pull just one leaf's slice out of a full stage log. */
 export function sectionForLeaf(log: string, kind: PipelineLeafKind): string {
   return parseLogSections(log)[kind];
+}
+
+// ── Full vertical model (global pre/post boxes + stages) ────────────────────
+
+/**
+ * A selectable step in the graph. A `job` step points at a real job's log
+ * section; an `info` step (controller-scope global script) has no captured
+ * output and just shows an explanatory message.
+ */
+export type StepRef =
+  | {
+      type: 'job';
+      key: string;
+      jobId: string;
+      kind: PipelineLeafKind;
+      label: string;
+      state: JobState;
+      exitCode: number | null;
+    }
+  | { type: 'info'; key: string; label: string; message: string; state: JobState };
+
+export interface GlobalBox {
+  present: boolean;
+  /** Sub-steps revealed on expand (worker / controller variants). */
+  steps: StepRef[];
+}
+
+export interface PipelineModel {
+  globalPre: GlobalBox;
+  stages: PipelineNode[];
+  globalPost: GlobalBox;
+}
+
+const isWorker = (scope?: string | null) => scope === 'worker' || scope === 'both';
+const isController = (scope?: string | null) => scope === 'controller' || scope === 'both';
+
+/** Convert a stage leaf into a selectable job step. */
+export function leafToStep(leaf: PipelineLeaf): StepRef {
+  return {
+    type: 'job',
+    key: leaf.key,
+    jobId: leaf.jobId,
+    kind: leaf.kind,
+    label: leaf.label,
+    state: leaf.state,
+    exitCode: leaf.exitCode,
+  };
+}
+
+/** Build the full vertical pipeline model from jobs + the group's repo-level
+ *  global scripts. */
+export function buildPipelineModel(jobs: Job[], group: JobGroup): PipelineModel {
+  const nodes = buildPipeline(jobs);
+  const stages = nodes.filter((n) => n.kind === 'stage');
+  const cleanup = nodes.find((n) => n.kind === 'global-post') ?? null;
+  const firstStage = stages[0] ?? null;
+
+  // Global pre-script: worker-scope is prepended to the first stage's pre
+  // phase (no separate job); controller-scope has no captured output.
+  const preSteps: StepRef[] = [];
+  if (isWorker(group.global_pre_script_scope)) {
+    const preLeaf = firstStage?.leaves.find((l) => l.kind === 'pre');
+    if (firstStage && preLeaf) {
+      preSteps.push({
+        type: 'job',
+        key: 'global-pre:worker',
+        jobId: firstStage.job.id,
+        kind: 'pre',
+        label: 'Worker',
+        state: preLeaf.state,
+        exitCode: preLeaf.exitCode,
+      });
+    }
+  }
+  if (isController(group.global_pre_script_scope)) {
+    preSteps.push({
+      type: 'info',
+      key: 'global-pre:controller',
+      label: 'Controller',
+      message: 'Global pre-script runs on the controller; its output is not captured.',
+      state: 'unknown',
+    });
+  }
+
+  // Global post-script: worker-scope is the __cleanup__ job; controller-scope
+  // has no captured output.
+  const postSteps: StepRef[] = [];
+  if (isWorker(group.global_post_script_scope)) {
+    if (cleanup) {
+      postSteps.push({
+        type: 'job',
+        key: 'global-post:worker',
+        jobId: cleanup.job.id,
+        kind: 'cmd',
+        label: 'Worker',
+        state: cleanup.state,
+        exitCode: cleanup.job.exit_code,
+      });
+    } else {
+      postSteps.push({
+        type: 'info',
+        key: 'global-post:worker',
+        label: 'Worker',
+        message: 'Global post-script runs on the worker at group completion (no record yet).',
+        state: 'queued',
+      });
+    }
+  }
+  if (isController(group.global_post_script_scope)) {
+    postSteps.push({
+      type: 'info',
+      key: 'global-post:controller',
+      label: 'Controller',
+      message: 'Global post-script runs on the controller; its output is not captured.',
+      state: 'unknown',
+    });
+  }
+
+  return {
+    globalPre: { present: !!group.global_pre_script, steps: preSteps },
+    stages,
+    globalPost: { present: !!group.global_post_script || !!cleanup, steps: postSteps },
+  };
 }

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -467,6 +467,7 @@ export default function BuildDetailPage() {
           global post-script) + right output pane for the selected step. */}
       <PipelineExplorer
         jobs={jobs}
+        group={group}
         filesPurgedAt={group.files_purged_at}
         onRetryJob={canCancelJobs ? openRetryJob : undefined}
       />

--- a/frontend/src/pages/BuildDetailPage.tsx
+++ b/frontend/src/pages/BuildDetailPage.tsx
@@ -3,14 +3,10 @@ import { clsx } from 'clsx';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getBuild, cancelBuild, retryBuild, retryJob } from '../api/builds';
-import apiClient from '../api/client';
 import { StatusBadge } from '../components/ui/StatusBadge';
 import { TimeAgo } from '../components/ui/TimeAgo';
-import { LogViewer } from '../components/log/LogViewer';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
-import { StageTimeline } from '../components/ui/StageTimeline';
-import { StageMetadata } from '../components/ui/StageMetadata';
-import { useLiveLog } from '../hooks/useLiveLog';
+import { PipelineExplorer } from '../components/pipeline/PipelineExplorer';
 import { usePermission } from '../hooks/usePermission';
 import { formatDuration } from '../utils/duration';
 import { formatSecs, formatBytes } from '../utils/format';
@@ -83,95 +79,6 @@ function ArchivedChildrenPanel({ children }: { children: ArchivedChildren }) {
 
 // ── Job log panel ─────────────────────────────────────────────────────────────
 
-interface JobLogPanelProps {
-  job: Job;
-  filesPurgedAt: string | null | undefined;
-  onRetry?: () => void;
-}
-
-function StageTimer({ job }: { job: Job }) {
-  const [now, setNow] = useState(Date.now());
-
-  useEffect(() => {
-    if (job.state !== 'running' || !job.started_at) return;
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [job.state, job.started_at]);
-
-  if (!job.started_at) return null;
-
-  const startMs = new Date(job.started_at).getTime();
-  const endMs = job.completed_at ? new Date(job.completed_at).getTime() : now;
-  const elapsedSecs = Math.max(0, Math.floor((endMs - startMs) / 1000));
-  const maxSecs = job.max_duration_secs || 0;
-
-  const h = Math.floor(elapsedSecs / 3600);
-  const m = Math.floor((elapsedSecs % 3600) / 60);
-  const s = elapsedSecs % 60;
-  const elapsed = h > 0 ? `${h}h ${m}m ${s}s` : m > 0 ? `${m}m ${s}s` : `${s}s`;
-
-  const maxH = Math.floor(maxSecs / 3600);
-  const maxM = Math.floor((maxSecs % 3600) / 60);
-  const maxLabel = maxSecs > 0
-    ? (maxH > 0 ? `${maxH}h ${maxM}m` : `${maxM}m`)
-    : null;
-
-  const pct = maxSecs > 0 ? elapsedSecs / maxSecs : 0;
-  const color = pct > 0.9 ? 'text-danger' : pct > 0.7 ? 'text-warning' : 'text-muted';
-
-  return (
-    <span className={`text-xs font-mono ${color}`}>
-      {elapsed}{maxLabel && ` / ${maxLabel}`}
-    </span>
-  );
-}
-
-function JobLogPanel({ job, filesPurgedAt, onRetry }: JobLogPanelProps) {
-  const isRunning = job.state === 'running' || job.state === 'assigned';
-  const { chunks } = useLiveLog(job.id, isRunning && !filesPurgedAt);
-
-  // For completed jobs, fetch logs via GET — but skip if files are gone.
-  const { data: logData } = useQuery({
-    queryKey: ['job-logs', job.id],
-    queryFn: () => apiClient.get(`/jobs/${job.id}/logs`).then((r) => r.data),
-    enabled: !isRunning && !!job.id && !filesPurgedAt,
-  });
-
-  const completedLogs = logData?.data || '';
-
-  return (
-    <div className="bg-surface border border-border rounded-xl">
-      <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <StatusBadge status={job.state} />
-          <h3 className="text-sm font-semibold text-secondary">{job.stage_name}</h3>
-        </div>
-        <div className="flex items-center gap-4 text-xs text-muted">
-          {job.exit_code !== null && <span>exit: {job.exit_code}</span>}
-          {job.status_reason && <span className="text-xs text-disabled">{job.status_reason}</span>}
-          <StageTimer job={job} />
-          {job.state === 'failed' && onRetry && (
-            <button
-              onClick={onRetry}
-              className="px-3 py-1 text-xs bg-warning-soft text-warning border border-warning/30 rounded-lg hover:opacity-80 transition-colors focus:outline-none focus:ring-2 focus:ring-warning"
-            >
-              Retry Stage
-            </button>
-          )}
-        </div>
-      </div>
-      <StageMetadata job={job} />
-      <div className="px-4 pb-4">
-        <LogViewer
-          content={isRunning ? undefined : completedLogs || `Stage: ${job.stage_name}\nState: ${job.state}\n`}
-          liveChunks={isRunning ? chunks : undefined}
-          filesPurgedAt={filesPurgedAt}
-          className="h-80"
-        />
-      </div>
-    </div>
-  );
-}
 
 interface TimerInfo {
   status: string;
@@ -388,8 +295,6 @@ export default function BuildDetailPage() {
   const { canCancelJobs } = usePermission();
   const [dialog, setDialog] = useState<DialogKind>(null);
   const [retryJobTarget, setRetryJobTarget] = useState<Job | null>(null);
-  const [selectedJob, setSelectedJob] = useState<Job | null>(null);
-
   const { data, isLoading, isError } = useQuery({
     queryKey: ['build', id],
     queryFn: () => getBuild(id!),
@@ -442,9 +347,6 @@ export default function BuildDetailPage() {
 
   const { job_group: group, jobs } = data;
   const isTerminal = ['success', 'failed', 'cancelled'].includes(group.state);
-
-  const activeSelectedJob =
-    selectedJob ?? jobs.find((j) => j.state === 'running') ?? jobs.find((j) => j.state === 'failed') ?? null;
 
   function openRetryJob(job: Job) {
     setRetryJobTarget(job);
@@ -561,36 +463,13 @@ export default function BuildDetailPage() {
         </div>
       )}
 
-      {/* Stage pipeline timeline. Per-stage timeout/countdown is rendered
-          inside each row (next to the stage name) by StageTimeline. */}
-      <div className="bg-surface border border-border rounded-xl">
-        <div className="px-4 py-3 border-b border-border">
-          <h3 className="text-sm font-semibold text-secondary">
-            Pipeline ({jobs.length} stage{jobs.length !== 1 ? 's' : ''})
-          </h3>
-        </div>
-        {jobs.length > 0 ? (
-          <div className="p-2">
-            <StageTimeline
-              jobs={jobs}
-              onSelectJob={(job) => setSelectedJob((prev) => (prev?.id === job.id ? null : job))}
-              selectedJobId={activeSelectedJob?.id}
-            />
-          </div>
-        ) : (
-          <div className="px-4 py-8 text-center text-disabled">No stages submitted yet</div>
-        )}
-      </div>
-
-      {/* Log panel for selected job */}
-      {activeSelectedJob && (
-        <JobLogPanel
-          key={activeSelectedJob.id}
-          job={activeSelectedJob}
-          filesPurgedAt={group.files_purged_at}
-          onRetry={canCancelJobs ? () => openRetryJob(activeSelectedJob) : undefined}
-        />
-      )}
+      {/* Pipeline explorer: left accordion tree (stages -> pre/cmd/post,
+          global post-script) + right output pane for the selected step. */}
+      <PipelineExplorer
+        jobs={jobs}
+        filesPurgedAt={group.files_purged_at}
+        onRetryJob={canCancelJobs ? openRetryJob : undefined}
+      />
 
       {/* Archived child records (collapsed by default) */}
       {group.archived && group.children && (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -46,8 +46,12 @@ export default function LoginPage() {
       const e = err as MutationError & { response?: unknown };
       if (!e.response) {
         toast.error('Cannot reach server. Check your connection.');
-      } else if (e.statusCode === 401 || e.statusCode === 403) {
+      } else if (e.statusCode === 401) {
         toast.error('Invalid credentials.');
+      } else if (e.statusCode === 403) {
+        // Not a credentials problem — e.g. a cross-origin/CSRF block. Show the
+        // backend's actual reason instead of misleading "Invalid credentials".
+        toast.error(e.userMessage || 'Request blocked.');
       } else if (e.statusCode && e.statusCode >= 500) {
         toast.error('Server error. Please try again later.');
       } else {

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -1241,9 +1241,13 @@ export default function WorkersPage() {
                 {/* item 55: pill chips for job types */}
                 <div className="flex items-center gap-1 flex-wrap">
                   <span className="text-disabled">Types:</span>
-                  {w.supported_job_types.map((t) => (
-                    <span key={t} className="px-1.5 py-0.5 bg-surface-2 text-secondary border border-border rounded text-[10px] font-mono">{t}</span>
-                  ))}
+                  {(w.supported_job_types ?? []).length > 0 ? (
+                    (w.supported_job_types ?? []).map((t) => (
+                      <span key={t} className="px-1.5 py-0.5 bg-surface-2 text-secondary border border-border rounded text-[10px] font-mono">{t}</span>
+                    ))
+                  ) : (
+                    <span className="text-disabled italic">none</span>
+                  )}
                 </div>
                 <span>Registered: <TimeAgo date={w.registered_at} /></span>
                 {w.last_heartbeat && <span>Last beat: <TimeAgo date={w.last_heartbeat.timestamp} /></span>}

--- a/frontend/src/types/build.ts
+++ b/frontend/src/types/build.ts
@@ -28,6 +28,11 @@ export interface JobGroup {
   reserved_stages?: string[];
   /** Stage names that have a submitted job. Derived from `jobs[].stage_name`. */
   submitted_stages?: string[];
+  /** Repo-level global scripts + scope (worker|controller|both). */
+  global_pre_script?: string | null;
+  global_pre_script_scope?: string | null;
+  global_post_script?: string | null;
+  global_post_script_scope?: string | null;
   allocated_resources?: AllocatedResources;
   last_activity_at?: string | null;
   time_until_timeout_secs?: number | null;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,10 +20,18 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,
+        // Forward the original host as X-Forwarded-Host so the backend's
+        // same-origin CSRF check passes when the dev server is reached over
+        // LAN/Tailscale (not just localhost).
+        xfwd: true,
       },
       '/health': {
         target: 'http://localhost:8080',
         changeOrigin: true,
+        // Forward the original host as X-Forwarded-Host so the backend's
+        // same-origin CSRF check passes when the dev server is reached over
+        // LAN/Tailscale (not just localhost).
+        xfwd: true,
       },
     },
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    // Localhost-only by default (secure). To reach the dev server over
+    // LAN/Tailscale, set VITE_HOST:
+    //   VITE_HOST=true       all interfaces (0.0.0.0)
+    //   VITE_HOST=100.x.y.z  bind the host's Tailscale IP (tailnet-only)
+    host: process.env.VITE_HOST === 'true' ? true : process.env.VITE_HOST,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',

--- a/nix/modules/frontend.nix
+++ b/nix/modules/frontend.nix
@@ -1,0 +1,87 @@
+{ self, lib, ... }:
+{
+  perSystem = { pkgs, ... }:
+    let
+      # vite runs a strict version check against the esbuild binary. The frontend
+      # lockfile pins esbuild 0.25.12, but nixpkgs ships 0.27.2 — the mismatch is
+      # what broke earlier builds. Pin a matching esbuild and hand it to vite via
+      # ESBUILD_BINARY_PATH (the sandboxed npm postinstall binary can't run).
+      esbuild-pinned = pkgs.esbuild.overrideAttrs (_old: {
+        version = "0.25.12";
+        src = pkgs.fetchFromGitHub {
+          owner = "evanw";
+          repo = "esbuild";
+          rev = "v0.25.12";
+          hash = "sha256-iyQP6q/nX4KEo3DZ6H6okgvGiiqatJPPp+mMDOFKu8c=";
+        };
+      });
+
+      # The built Vite `dist/` as its own artifact. `nix build .#chola-frontend`
+      # yields a copyable directory of static assets — deploy it independently of
+      # the backend (behind any static server), or run it via the app below.
+      chola-frontend-dist = pkgs.buildNpmPackage {
+        pname = "chola-frontend";
+        version = "0.1.0";
+
+        src = lib.cleanSourceWith {
+          src = self + "/frontend";
+          # Don't hash node_modules/dist into the source.
+          filter = path: _type:
+            !(lib.hasInfix "/node_modules" path) && !(lib.hasInfix "/dist" path);
+        };
+
+        npmDepsHash = "sha256-C8qfSFPQ/U7wNO7euSkExmRGvinQUc9BZyzzqHK+uoY=";
+
+        ESBUILD_BINARY_PATH = "${esbuild-pinned}/bin/esbuild";
+
+        # rollup 4 ships native code as platform optionalDependencies.
+        npmFlags = [ "--include=optional" ];
+
+        # `npm run build` = tsc -b && vite build → dist/
+        installPhase = ''
+          runHook preInstall
+          cp -r dist $out
+          runHook postInstall
+        '';
+      };
+
+      # Serve the built SPA and reverse-proxy /api to the backend, so the browser
+      # only ever sees one origin (no CORS). Backend URL and listen port are
+      # runtime env vars — the same dist serves any backend.
+      caddyfile = pkgs.writeText "Caddyfile" ''
+        {
+          admin off
+          auto_https off
+        }
+        :{$CHOLA_FRONTEND_PORT:3000} {
+          handle /api/* {
+            reverse_proxy {$CHOLA_BACKEND_URL:localhost:8080}
+          }
+          handle {
+            root * ${chola-frontend-dist}
+            try_files {path} /index.html
+            file_server
+          }
+        }
+      '';
+
+      chola-frontend-server = pkgs.writeShellApplication {
+        name = "chola-frontend";
+        runtimeInputs = [ pkgs.caddy ];
+        text = ''
+          echo "chola-frontend: serving on :''${CHOLA_FRONTEND_PORT:-3000}, /api -> ''${CHOLA_BACKEND_URL:-localhost:8080}"
+          exec caddy run --config ${caddyfile} --adapter caddyfile
+        '';
+      };
+    in
+    {
+      # nix build .#chola-frontend  -> ./result = static dist/ (copy anywhere)
+      packages.chola-frontend = chola-frontend-dist;
+
+      # nix run   .#chola-frontend  -> Caddy serving the dist + /api proxy
+      apps.chola-frontend = {
+        type = "app";
+        program = "${chola-frontend-server}/bin/chola-frontend";
+      };
+    };
+}


### PR DESCRIPTION
Closes #26

## Summary
Separates frontend deployment from the controller, reworks build detail into a
pipeline explorer, fixes LAN/Tailscale login/origin handling, and closes a
worker cleanup/path correctness gap around the unified scratch layout.

## Controller / API
- **fix:** make the HTTP bind address configurable and secure by default
  (`127.0.0.1` unless explicitly overridden).
- **fix:** allow same-origin mutating requests for the actual served host
  (`Host` / `X-Forwarded-Host`) instead of hardcoding localhost-only origin
  handling; keep explicit `allowed_origins` support for real cross-origin setups.
- **feat:** expose job `pre_script` / `post_script` and repo global
  pre/post-script scope in build-detail responses so the frontend can render the
  full pipeline model.
- **fix:** normalize `supported_job_types` to `[]` in the workers API.
- **fix:** remove stale `worker_tokens` on worker delete / re-register so the
  worker_id unique index no longer causes collisions.

## Frontend
- **feat:** replace the old build-detail stage view with a pipeline explorer:
  left-side expandable graph/tree, right-side step output, retry button on the
  selected failed stage.
- **feat:** add pipeline model + log-section parsing for `pre` / `cmd` / `post`
  output slices and Blue-Ocean-style parallel branch rendering.
- **fix:** distinguish 401 vs 403 on login; 403 now shows the backend’s real
  message instead of the misleading "Invalid credentials".
- **fix:** forward `X-Forwarded-Host` in the Vite dev proxy so same-origin
  checks work over LAN/Tailscale dev hosts.

## Nix / deployment
- **feat:** add a standalone `chola-frontend` Nix package that builds the Vite
  `dist/` as a deployable artifact.
- **feat:** add a `chola-frontend` app backed by Caddy that serves the SPA and
  reverse-proxies `/api`, giving a simple single-origin deployment path.

## Worker scratch / cleanup correctness
- **refactor:** keep grouped jobs on the unified
  `worker/scratch/<gid>/{workspace,logs,stages}` layout instead of falling back
  to legacy `worker/jobs` / `worker/logs` paths.
- **fix:** run cleanup jobs from a safe parent directory so a global post-script
  can delete `CHOLA_WORK_DIR` without breaking the synthetic follow-up command.

## Test plan
- [ ] Build frontend via `nix build .#chola-frontend`
- [ ] Serve frontend via `nix run .#chola-frontend` and verify `/api` proxying
- [ ] Verify login POST succeeds over localhost, LAN IP, and Tailscale hostname
      when frontend/API are same-origin
- [ ] Verify 403 login shows backend error text, while 401 still shows invalid
      credentials
- [ ] Verify build detail renders global pre/post steps and per-stage
      `pre/cmd/post` output
- [ ] Verify a parallel build renders split graph lanes
- [ ] Verify grouped jobs, including `__cleanup__`, use only
      `worker/scratch/<gid>/...`
- [ ] Verify a cleanup script that removes `CHOLA_WORK_DIR` no longer fails with
      `No such file or directory (os error 2)`
- [ ] Verify worker delete / re-register does not hit token unique-key conflicts