### PR TITLE
28: register migration 034 — fix reserved_stages column missing

### DIFF
--- a/crates/ci-controller/src/storage.rs
+++ b/crates/ci-controller/src/storage.rs
@@ -1079,6 +1079,11 @@ impl Storage {
                 "retention_archive",
                 include_str!("../../../migrations/033_retention_archive.sql"),
             ),
+            (
+                34,
+                "reserved_stages",
+                include_str!("../../../migrations/034_reserved_stages.sql"),
+            ),
         ];
 
         for (version, name, sql) in migrations {


### PR DESCRIPTION
Closes #28

## Summary

Migration `034_reserved_stages.sql` was never registered in the in-code
migration runner, so prod never got the `reserved_stages` column on
`job_groups` / `job_groups_archive`. Every query using `JOB_GROUP_COLUMNS`
(SELECT, INSERT, RETURNING) failed with a SQL error, breaking `/builds`,
dashboard, and blocking all new build creation.

## Fix

Register migration 034 in the `migrations` array in `storage.rs` so it
runs automatically on next controller startup.
